### PR TITLE
ESP-IDF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ This project maintains all functionalities of the original geoffdavis project, i
 ## Supported Microcontrollers:
 - WeMos D1 Mini (ESP8266): tested
 - M5Stack ATOM Lite : tested
-- Generic ESP32 Dev Kit (ESP32): Compile ok but Not tested
-- Generic ESP-01S board (ESP8266): Not tested
+- Generic ESP32 Dev Kit (ESP32): tested
+
 
 ## Supported Mitsubishi Climate Units:
 Primarily, units with a `CN105` header are compatible. Refer to the [HeatPump wiki](https://github.com/SwiCago/HeatPump/wiki/Supported-models) for a comprehensive list. 
@@ -50,12 +50,19 @@ external_components:
 ```
 
 ### Step 4: Configuring the Heatpump
-In your ESPHome config, add a `mitsubishi_heatpump` component:
+
+In your ESPHome config, configure an uart and add a `cn105` component:
 ```yaml
+
+uart:
+  id: HP_UART
+  baud_rate: 2400
+  tx_pin: 1
+  rx_pin: 3
+
 climate:
   - platform: cn105 # Choose your platform
-    name: "My Heat Pump"
-    hardware_uart: UART0
+    name: "My Heat Pump"    
     update_interval: 4s
 ```
 Note: The `update_interval` is set here to 4s for debugging purposes. However, it is recommended to use a interval longer or equal to 1s because the underlying process divides this interval into three separate requests.
@@ -84,7 +91,7 @@ esphome:
   friendly_name: ${friendly_name}
 
 esp8266:
-  board: esp01_1m
+  board: d1_mini
 
 # Enable logging
 logger:
@@ -108,17 +115,22 @@ ota:
 external_components:
   - source: github://echavet/MitsubishiCN105ESPHome
 
+uart:
+  id: HP_UART
+  baud_rate: 2400
+  tx_pin: 1
+  rx_pin: 3
+
 climate:
   - platform: cn105 # remplis avec la plateforme de ton choix
     name: ${friendly_name}
-    id: "clim_id"
-    baud_rate: 0
-    hardware_uart: UART0
-
+    id: "clim_id"    
+    
     # this update interval is not the same as the original geoffdavis parameter
     # this one activates the autoupdate feature (or not is set to 0)
     # the underlying component is not a PollingComponent so the component just uses
-    # the espHome scheduler to program the heatpump requests at the given interval.    
+    # the espHome scheduler to program the heatpump requests at the given interval.
+    # 3 requests are sent each update_interval with an interval of update_interval/4 or 300ms.
     update_interval: 4s
 ```
 

--- a/components/cn105/Globals.h
+++ b/components/cn105/Globals.h
@@ -138,8 +138,8 @@ struct heatpumpSettings {
             mode == other.mode &&
             temperature == other.temperature &&
             fan == other.fan &&
-            vane == other.vane;
-        // && wideVane == other.wideVane &&
+            vane == other.vane &&
+            wideVane == other.wideVane;
         //iSee == other.iSee;
     }
 

--- a/components/cn105/Globals.h
+++ b/components/cn105/Globals.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <esphome.h>
-#include <esphome/core/preferences.h>
+#include "esphome/components/uart/uart.h"
 
 #if defined(ARDUINO) && ARDUINO >= 100
 #include "Arduino.h"

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -3,30 +3,42 @@ import esphome.config_validation as cv
 from esphome.components import climate, uart
 from esphome.components import select
 from esphome.components.logger import HARDWARE_UART_TO_SERIAL
+from esphome.components.uart import UARTParityOptions
 
 from esphome.const import (
     CONF_ID,
-    CONF_HARDWARE_UART,
-    CONF_BAUD_RATE,
     CONF_UPDATE_INTERVAL,
     CONF_MODE,
     CONF_FAN_MODE,
     CONF_SWING_MODE,
+    CONF_UART_ID,
 )
 from esphome.core import CORE, coroutine
 
-AUTO_LOAD = ["climate", "sensor", "select", "binary_sensor", "text_sensor"]
+AUTO_LOAD = ["climate", "sensor", "select", "binary_sensor", "text_sensor", "uart"]
 
 CONF_SUPPORTS = "supports"
 DEFAULT_CLIMATE_MODES = ["HEAT_COOL", "COOL", "HEAT", "DRY", "FAN_ONLY"]
 DEFAULT_FAN_MODES = ["AUTO", "QUIET", "LOW", "MEDIUM", "HIGH"]
 DEFAULT_SWING_MODES = ["OFF", "VERTICAL", "HORIZONTAL", "BOTH"]
 
+# from https://github.com/wrouesnel/esphome-mitsubishiheatpump/blob/master/components/mitsubishi_heatpump/climate.py
+# HORIZONTAL_SWING_OPTIONS = [
+#     "AUTO",
+#     "SWING",
+#     "LEFT",
+#     "LEFT_CENTER",
+#     "CENTER",
+#     "RIGHT_CENTER",
+#     "RIGHT",
+# ]
+
+
 # Déclaration des constantes pour TX et RX pin
 CONF_TX_PIN = "tx_pin"
 CONF_RX_PIN = "rx_pin"
 
-CN105Climate = cg.global_ns.class_("CN105Climate", climate.Climate, cg.PollingComponent)
+CN105Climate = cg.global_ns.class_("CN105Climate", climate.Climate, cg.Component)
 
 
 def valid_uart(uart):
@@ -43,10 +55,8 @@ def valid_uart(uart):
 CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(CN105Climate),
-        cv.Optional(CONF_HARDWARE_UART, default="UART0"): valid_uart,
-        cv.Optional(CONF_BAUD_RATE): cv.positive_int,
-        cv.Optional(CONF_TX_PIN): cv.positive_int,
-        cv.Optional(CONF_RX_PIN): cv.positive_int,
+        cv.GenerateID(CONF_UART_ID): cv.use_id(uart.UARTComponent),
+        # cv.Optional(CONF_HARDWARE_UART, default="UART0"): valid_uart,
         cv.Optional(CONF_UPDATE_INTERVAL, default="0ms"): cv.All(cv.update_interval),
         # Optionally override the supported ClimateTraits.
         cv.Optional(CONF_SUPPORTS, default={}): cv.Schema(
@@ -68,17 +78,16 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
 
 @coroutine
 def to_code(config):
-    serial = HARDWARE_UART_TO_SERIAL[config[CONF_HARDWARE_UART]]
-    var = cg.new_Pvariable(config[CONF_ID], cg.RawExpression(f"&{serial}"))
+    # serial = HARDWARE_UART_TO_SERIAL[config[CONF_HARDWARE_UART]]
+    # var = cg.new_Pvariable(config[CONF_ID], cg.RawExpression(f"&{serial}"))
 
-    if CONF_BAUD_RATE in config:
-        cg.add(var.set_baud_rate(config[CONF_BAUD_RATE]))
+    uart_var = yield cg.get_variable(config["uart_id"])
 
-    # Traitement des configurations de broches TX et RX
-    if CONF_TX_PIN in config and CONF_RX_PIN in config:
-        tx_pin = config[CONF_TX_PIN]
-        rx_pin = config[CONF_RX_PIN]
-        cg.add(var.set_tx_rx_pins(tx_pin, rx_pin))
+    var = cg.new_Pvariable(config[CONF_ID], uart_var)
+
+    cg.add(uart_var.set_data_bits(8))
+    cg.add(uart_var.set_parity(UARTParityOptions.UART_CONFIG_PARITY_EVEN))
+    cg.add(uart_var.set_stop_bits(1))
 
     supports = config[CONF_SUPPORTS]
     traits = var.config_traits()

--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -199,8 +199,16 @@ void CN105Climate::setActionIfOperatingTo(climate::ClimateAction action) {
     }
     ESP_LOGD(TAG, "setting action to -> %d", this->action);
 }
-
+/**
+ * Thanks to Bascht74 on issu #9 we know that the compressor frequency is not a good indicator of the heatpump being in operation
+ * Because one can have multiple inside module for a single compressor.
+ * Also, some heatpump does not support compressor frequency.
+ * SO usage is deprecated.
+*/
 void CN105Climate::setActionIfOperatingAndCompressorIsActiveTo(climate::ClimateAction action) {
+
+    ESP_LOGW(TAG, "Warning: the use of compressor frequency as an active indicator is deprecated. Please use operating status instead.");
+
     if (currentStatus.compressorFrequency <= 0) {
         this->action = climate::CLIMATE_ACTION_IDLE;
     } else {
@@ -212,19 +220,23 @@ void CN105Climate::updateAction() {
     ESP_LOGV(TAG, "updating action back to espHome...");
     switch (this->mode) {
     case climate::CLIMATE_MODE_HEAT:
-        this->setActionIfOperatingAndCompressorIsActiveTo(climate::CLIMATE_ACTION_HEATING);
+        //this->setActionIfOperatingAndCompressorIsActiveTo(climate::CLIMATE_ACTION_HEATING);       
+        this->setActionIfOperatingTo(climate::CLIMATE_ACTION_HEATING);
         break;
     case climate::CLIMATE_MODE_COOL:
-        this->setActionIfOperatingAndCompressorIsActiveTo(climate::CLIMATE_ACTION_COOLING);
+        //this->setActionIfOperatingAndCompressorIsActiveTo(climate::CLIMATE_ACTION_COOLING);
+        this->setActionIfOperatingTo(climate::CLIMATE_ACTION_COOLING);
         break;
     case climate::CLIMATE_MODE_HEAT_COOL:
-        this->setActionIfOperatingAndCompressorIsActiveTo(
+        //this->setActionIfOperatingAndCompressorIsActiveTo(
+        this->setActionIfOperatingTo(
             (this->current_temperature > this->target_temperature ?
                 climate::CLIMATE_ACTION_COOLING :
                 climate::CLIMATE_ACTION_HEATING));
         break;
     case climate::CLIMATE_MODE_DRY:
-        this->setActionIfOperatingAndCompressorIsActiveTo(climate::CLIMATE_ACTION_DRYING);
+        //this->setActionIfOperatingAndCompressorIsActiveTo(climate::CLIMATE_ACTION_DRYING);
+        this->setActionIfOperatingTo(climate::CLIMATE_ACTION_DRYING);
         break;
     case climate::CLIMATE_MODE_FAN_ONLY:
         this->action = climate::CLIMATE_ACTION_FAN;

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -4,18 +4,17 @@
 
 using namespace esphome;
 
-
 class VaneOrientationSelect;  // Déclaration anticipée, définie dans extraComponents
 
 
 
-class CN105Climate : public climate::Climate, public Component {
+class CN105Climate : public climate::Climate, public Component, public uart::UARTDevice {
 
     friend class VaneOrientationSelect;
 
 public:
 
-
+    CN105Climate(uart::UARTComponent* hw_serial);
 
     sensor::Sensor* compressor_frequency_sensor;
     binary_sensor::BinarySensor* iSee_sensor;
@@ -36,7 +35,7 @@ public:
     }
 
 
-    CN105Climate(HardwareSerial* hw_serial);
+
 
     void generateExtraComponents();
 
@@ -106,13 +105,9 @@ protected:
 
     climate::ClimateTraits traits_;
     //Accessor method for the HardwareSerial pointer
-    HardwareSerial* get_hw_serial_() {
-        return this->hw_serial_;
+    uart::UARTComponent* get_hw_serial_() {
+        return this->parent_;
     }
-
-    //Print a warning message if we're using the sole hardware UART on an
-        //ESP8266 or UART0 on ESP32
-    void check_logger_conflict_();
 
     bool processInput(void);
     void parse(uint8_t inputData);
@@ -175,7 +170,6 @@ private:
     unsigned long lastResponseMs;
 
 
-    HardwareSerial* hw_serial_;
     int baud_ = 0;
     int tx_pin_ = -1;
     int rx_pin_ = -1;

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -17,17 +17,18 @@ void CN105Climate::setup() {
     this->swing_mode = climate::CLIMATE_SWING_OFF;
     this->initBytePointer();
 
-    ESP_LOGI(
-        TAG,
-        "hw_serial(%p) is &Serial(%p)? %s",
-        this->get_hw_serial_(),
-        &Serial,
-        YESNO(this->get_hw_serial_() == &Serial)
-    );
+    /* ESP_LOGI(
+         TAG,
+         "hw_serial(%p) is &Serial(%p)? %s",
+         this->get_hw_serial_(),
+         &Serial,
+         YESNO(this->get_hw_serial_() == &Serial)
+     );*/
 
     ESP_LOGI(TAG, "bauds: %d", this->baud_);
 
-    this->check_logger_conflict_();
+    //check_logger_conflict_ is called from the UART abstraction
+    //this->check_logger_conflict_();
 
     this->setupUART();
     this->sendFirstConnectionPacket();

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -67,7 +67,7 @@ bool CN105Climate::checkSum() {
     ESP_LOGV("chkSum", "controling chkSum should be: %02X ", packetCheckSum);
 
     for (int i = 0;i < this->dataLength + 5;i++) {
-        ESP_LOGV("chkSum", "adding %02X to %02X --> ", this->storedInputData[i], processedCS, processedCS + this->storedInputData[i]);
+        ESP_LOGV("chkSum", "adding %02X to %03X --> %X", this->storedInputData[i], processedCS, processedCS + this->storedInputData[i]);
         processedCS += this->storedInputData[i];
     }
 
@@ -530,7 +530,11 @@ void CN105Climate::checkFanSettings(heatpumpSettings& settings) {
         } else { //case "AUTO" or default:
             this->fan_mode = climate::CLIMATE_FAN_AUTO;
         }
-        ESP_LOGD(TAG, "Fan mode is: %i", this->fan_mode);
+        if (this->fan_mode.has_value()) {
+            ESP_LOGD(TAG, "Fan mode is: %i", static_cast<int>(this->fan_mode.value()));
+        } else {
+            ESP_LOGD(TAG, "Fan mode is not set");
+        }
     }
 }
 void CN105Climate::checkPowerAndModeSettings(heatpumpSettings& settings) {

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -99,8 +99,11 @@ bool CN105Climate::processInput(void) {
     bool processed = false;
     while (this->get_hw_serial_()->available()) {
         processed = true;
-        int inputData = this->get_hw_serial_()->read();
-        parse(inputData);
+        u_int8_t inputData;
+        if (this->get_hw_serial_()->read_byte(&inputData)) {
+            parse(inputData);
+        }
+
     }
     return processed;
 }

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -486,17 +486,34 @@ void CN105Climate::settingsChanged(heatpumpSettings settings, const char* source
 }*/
 
 void CN105Climate::checkVaneSettings(heatpumpSettings& settings) {
+
     /* ******** HANDLE MITSUBISHI VANE CHANGES ********
-         * const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
-         */
-    if (this->hasChanged(currentSettings.vane, settings.vane, "vane")) { // vane setting change ?
-        ESP_LOGI(TAG, "vane setting changed");
+     * VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
+     * WIDEVANE_MAP[7]    = { "<<", "<",  "|",  ">",  ">>", "<>", "SWING" }
+     */
+
+    if (this->hasChanged(currentSettings.vane, settings.vane, "vane") ||                // vane setting change ?
+        this->hasChanged(currentSettings.wideVane, settings.wideVane, "wideVane")) {    // widevane setting change ?
+        ESP_LOGI(TAG, "vane or widevane setting changed");
+
+        // here I hope that the vane and widevane are always sent together
+
         currentSettings.vane = settings.vane;
+        currentSettings.wideVane = settings.wideVane;
 
         if (strcmp(currentSettings.vane, "SWING") == 0) {
-            this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+            if (strcmp(currentSettings.wideVane, "SWING") == 0) {
+                this->swing_mode = climate::CLIMATE_SWING_BOTH;
+            } else {
+                this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+            }
+
         } else {
-            this->swing_mode = climate::CLIMATE_SWING_OFF;
+            if (strcmp(currentSettings.wideVane, "SWING") == 0) {
+                this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+            } else {
+                this->swing_mode = climate::CLIMATE_SWING_OFF;
+            }
         }
         ESP_LOGD(TAG, "Swing mode is: %i", this->swing_mode);
     }

--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -78,17 +78,13 @@ void CN105Climate::writePacket(uint8_t* packet, int length, bool checkIsActive) 
     if ((this->isConnected_) &&
         (this->isHeatpumpConnectionActive() || (!checkIsActive))) {
 
-        if (this->get_hw_serial_()->availableForWrite() >= length) {
-            ESP_LOGD(TAG, "writing packet...");
-            this->hpPacketDebug(packet, length, "WRITE");
+        ESP_LOGD(TAG, "writing packet...");
+        this->hpPacketDebug(packet, length, "WRITE");
 
-            for (int i = 0; i < length; i++) {
-                this->get_hw_serial_()->write((uint8_t)packet[i]);
-            }
-        } else {
-            ESP_LOGW(TAG, "delaying packet writing because serial buffer is not ready...");
-            this->set_timeout("write", 200, [this, packet, length]() { this->writePacket(packet, length); });
+        for (int i = 0; i < length; i++) {
+            this->get_hw_serial_()->write_byte((uint8_t)packet[i]);
         }
+
     } else {
         ESP_LOGW(TAG, "could not write as asked, because UART is not connected");
         this->disconnectUART();

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -44,24 +44,26 @@ const char* getIfNotNull(const char* what, const char* defaultValue) {
 
 void CN105Climate::debugSettings(const char* settingName, wantedHeatpumpSettings settings) {
 #ifdef USE_ESP32
-    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%s]-> [power: %s, target °C: %2f, mode: %s, fan: %s, vane: %s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
+    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%s]-> [power: %s, target °C: %2f, mode: %s, fan: %s, vane: %s, wvane: %s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
         getIfNotNull(settingName, "unnamed"),
         getIfNotNull(settings.power, "-"),
         settings.temperature,
         getIfNotNull(settings.mode, "-"),
         getIfNotNull(settings.fan, "-"),
         getIfNotNull(settings.vane, "-"),
+        getIfNotNull(settings.wideVane, "-"),
         settings.hasChanged ? "YES" : " NO",
         settings.hasBeenSent ? "YES" : " NO"
     );
 #else
-    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%-*s]-> [power: %-*s, target °C: %2f, mode: %-*s, fan: %-*s, vane: %-*s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
+    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%-*s]-> [power: %-*s, target °C: %2f, mode: %-*s, fan: %-*s, vane: %-*s, wvane: %-*s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
         15, getIfNotNull(settingName, "unnamed"),
         3, getIfNotNull(settings.power, "-"),
         settings.temperature,
         6, getIfNotNull(settings.mode, "-"),
         6, getIfNotNull(settings.fan, "-"),
         6, getIfNotNull(settings.vane, "-"),
+        6, getIfNotNull(settings.wideVane, "-"),
         settings.hasChanged ? "YES" : " NO",
         settings.hasBeenSent ? "YES" : " NO"
     );
@@ -70,22 +72,24 @@ void CN105Climate::debugSettings(const char* settingName, wantedHeatpumpSettings
 
 void CN105Climate::debugSettings(const char* settingName, heatpumpSettings settings) {
 #ifdef USE_ESP32
-    ESP_LOGI(LOG_SETTINGS_TAG, "[%s]-> [power: %s, target °C: %2f, mode: %s, fan: %s, vane: %s]",
+    ESP_LOGI(LOG_SETTINGS_TAG, "[%s]-> [power: %s, target °C: %2f, mode: %s, fan: %s, vane: %s, wvane: %s]",
         getIfNotNull(settingName, "unnamed"),
         getIfNotNull(settings.power, "-"),
         settings.temperature,
         getIfNotNull(settings.mode, "-"),
         getIfNotNull(settings.fan, "-"),
-        getIfNotNull(settings.vane, "-")
+        getIfNotNull(settings.vane, "-"),
+        getIfNotNull(settings.wideVane, "-")
     );
 #else
-    ESP_LOGI(LOG_SETTINGS_TAG, "[%-*s]-> [power: %-*s, target °C: %2f, mode: %-*s, fan: %-*s, vane: %-*s]",
+    ESP_LOGI(LOG_SETTINGS_TAG, "[%-*s]-> [power: %-*s, target °C: %2f, mode: %-*s, fan: %-*s, vane: %-*s, wvane: %-*s]",
         15, getIfNotNull(settingName, "unnamed"),
         3, getIfNotNull(settings.power, "-"),
         settings.temperature,
         6, getIfNotNull(settings.mode, "-"),
         6, getIfNotNull(settings.fan, "-"),
-        6, getIfNotNull(settings.vane, "-")
+        6, getIfNotNull(settings.vane, "-"),
+        6, getIfNotNull(settings.wideVane, "-")
     );
 #endif
 }

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -43,7 +43,19 @@ const char* getIfNotNull(const char* what, const char* defaultValue) {
 }
 
 void CN105Climate::debugSettings(const char* settingName, wantedHeatpumpSettings settings) {
-    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%-*s]-> [power: %-*s, target °C: %2f, mode: %-*s, fan: %-*s, vane: %-*s, hasChanged ? -> %s]",
+#ifdef USE_ESP32
+    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%s]-> [power: %s, target °C: %2f, mode: %s, fan: %s, vane: %s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
+        getIfNotNull(settingName, "unnamed"),
+        getIfNotNull(settings.power, "-"),
+        settings.temperature,
+        getIfNotNull(settings.mode, "-"),
+        getIfNotNull(settings.fan, "-"),
+        getIfNotNull(settings.vane, "-"),
+        settings.hasChanged ? "YES" : " NO",
+        settings.hasBeenSent ? "YES" : " NO"
+    );
+#else
+    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%-*s]-> [power: %-*s, target °C: %2f, mode: %-*s, fan: %-*s, vane: %-*s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
         15, getIfNotNull(settingName, "unnamed"),
         3, getIfNotNull(settings.power, "-"),
         settings.temperature,
@@ -53,9 +65,20 @@ void CN105Climate::debugSettings(const char* settingName, wantedHeatpumpSettings
         settings.hasChanged ? "YES" : " NO",
         settings.hasBeenSent ? "YES" : " NO"
     );
+#endif
 }
 
 void CN105Climate::debugSettings(const char* settingName, heatpumpSettings settings) {
+#ifdef USE_ESP32
+    ESP_LOGI(LOG_SETTINGS_TAG, "[%s]-> [power: %s, target °C: %2f, mode: %s, fan: %s, vane: %s]",
+        getIfNotNull(settingName, "unnamed"),
+        getIfNotNull(settings.power, "-"),
+        settings.temperature,
+        getIfNotNull(settings.mode, "-"),
+        getIfNotNull(settings.fan, "-"),
+        getIfNotNull(settings.vane, "-")
+    );
+#else
     ESP_LOGI(LOG_SETTINGS_TAG, "[%-*s]-> [power: %-*s, target °C: %2f, mode: %-*s, fan: %-*s, vane: %-*s]",
         15, getIfNotNull(settingName, "unnamed"),
         3, getIfNotNull(settings.power, "-"),
@@ -64,17 +87,24 @@ void CN105Climate::debugSettings(const char* settingName, heatpumpSettings setti
         6, getIfNotNull(settings.fan, "-"),
         6, getIfNotNull(settings.vane, "-")
     );
+#endif
 }
 
 
 void CN105Climate::debugStatus(const char* statusName, heatpumpStatus status) {
-
+#ifdef USE_ESP32
+    ESP_LOGI(LOG_STATUS_TAG, "[%s]-> [room C°: %.1f, operating: %s, compressor freq: %2d Hz]",
+        statusName,
+        status.roomTemperature,
+        status.operating ? "YES" : "NO ",
+        status.compressorFrequency);
+#else
     ESP_LOGI(LOG_STATUS_TAG, "[%-*s]-> [room C°: %.1f, operating: %-*s, compressor freq: %2d Hz]",
         15, statusName,
         status.roomTemperature,
         3, status.operating ? "YES" : "NO ",
         status.compressorFrequency);
-
+#endif
 }
 
 

--- a/esp32-test.yaml
+++ b/esp32-test.yaml
@@ -13,11 +13,6 @@ esp32:
     #type: arduino
 
 
-uart:
-  id: HP_UART
-  baud_rate: 2400
-  tx_pin: 0
-  rx_pin: 3
   
     
 
@@ -31,17 +26,17 @@ uart:
 # Enable logging
 logger:  
   hardware_uart: UART0
-  level: INFO
-  logs:
-    CN105Climate: WARN
-    CN105: WARN
-    climate: WARN
-    sensor: WARN
-    chkSum : INFO
-    WRITE : WARN
-    READ : WARN
-    Header: INFO
-    Decoder : WARN
+  level: VERBOSE
+  # logs:
+  #   CN105Climate: WARN
+  #   CN105: WARN
+  #   climate: WARN
+  #   sensor: WARN
+  #   chkSum : INFO
+  #   WRITE : WARN
+  #   READ : WARN
+  #   Header: INFO
+  #   Decoder : WARN
     
 
 # Enable Home Assistant API
@@ -142,13 +137,19 @@ sensor:
   #   lambda: |-
   #     return(id(clim_sejour).get_compressor_frequency());
 
+uart:
+  id: HP_UART
+  baud_rate: 2400
+  tx_pin: 0
+  rx_pin: 3
+  
 # Configuration pour l'objet 'climate'
 climate:
   - platform: cn105  # remplis avec la plateforme de ton choix
     name: ${friendly_name}
     id: "clim_sejour"
-    baud_rate: 2400
-    #hardware_uart: UART1
+    # baud_rate: 2400
+    # hardware_uart: UART1
     update_interval: 10s         # shouldn't be less than 4 seconds
     # Ajoute d'autres paramètres spécifiques à ton matériel et tes besoins
 

--- a/esp32-test.yaml
+++ b/esp32-test.yaml
@@ -140,9 +140,9 @@ sensor:
 uart:
   id: HP_UART
   baud_rate: 2400
-  tx_pin: 0
+  tx_pin: 1
   rx_pin: 3
-  
+
 # Configuration pour l'objet 'climate'
 climate:
   - platform: cn105  # remplis avec la plateforme de ton choix

--- a/esp32-test.yaml
+++ b/esp32-test.yaml
@@ -11,6 +11,16 @@ esp32:
   framework:
     type: esp-idf     
     #type: arduino
+
+
+uart:
+  id: HP_UART
+  baud_rate: 2400
+  tx_pin: 0
+  rx_pin: 3
+  
+    
+
 # mqtt:  
 #   broker: 10.1.101.172
 #   username: heatpumpSejour
@@ -36,12 +46,7 @@ logger:
 
 # Enable Home Assistant API
 api:
-  services:
-    - service: reboot
-      then:
-        - logger.log: "Redémarrage en cours..."
-        - lambda: |-
-            ESP.restart();
+  services:    
     - service: set_remote_temperature
       variables:
         temperature: float
@@ -143,7 +148,7 @@ climate:
     name: ${friendly_name}
     id: "clim_sejour"
     baud_rate: 2400
-    hardware_uart: UART1
+    #hardware_uart: UART1
     update_interval: 10s         # shouldn't be less than 4 seconds
     # Ajoute d'autres paramètres spécifiques à ton matériel et tes besoins
 

--- a/hp-sejour.yaml
+++ b/hp-sejour.yaml
@@ -9,13 +9,20 @@ esphome:
  
 esp8266:
   board: esp01_1m
-  
+
+uart:
+  id: HP_UART
+  baud_rate: 2400
+  tx_pin: 1
+  rx_pin: 3
+
 mqtt:  
   broker: homeassistant.local
   username: heatpumpSejour
   password: !secret mqtt_password
   discovery: true
-  
+
+
 
 # Enable logging
 logger:  
@@ -127,67 +134,12 @@ sensor:
     name: ${name} WiFi Signal
     update_interval: 60s
   
-  # Etat de l'attribut operating décodé dans les trames de réponse du clim
-  # - platform: template
-  #   name: Operating (Clim)
-  #   update_interval: 10s
-  #   lambda: |-
-  #     return(id(clim_sejour).is_operating());
-  
-  # Etat de l'attribut compressor°frequency décodé dans les trames de réponse du clim
-  # généré dynamiquement dans le code de la clim
-  # - platform: template
-  #   name: Compressor Frequency (Clim)
-  #   update_interval: 10s
-  #   lambda: |-
-  #     return(id(clim_sejour).get_compressor_frequency());
 
 # Configuration pour l'objet 'climate'
 climate:
   - platform: cn105  # remplis avec la plateforme de ton choix
     name: ${friendly_name}
-    id: "clim_sejour"
-    baud_rate: 2400
-    hardware_uart: UART0
-    #tx_pin: 1
-    #rx_pin: 3
+    id: "clim_sejour"    
     update_interval: 10s         # shouldn't be less than 1 second
     # Ajoute d'autres paramètres spécifiques à ton matériel et tes besoins
 
-
-# Configuration pour l'objet 'switch' (bouton)
-# switch:
-#   - platform: template
-#     name: ${name} UART Setup Switch
-#     id: uart_setup_switch
-#     entity_category: DIAGNOSTIC
-#     #setup_priority : -100.0 ## late
-#     optimistic: true
-#     turn_on_action:
-#       - lambda: |-
-#           // Appelle la méthode 'setupUART' quand le switch est activé
-#           id(clim_sejour).setupUART();
-#     turn_off_action:
-#       - lambda: |-
-#           // Appelle la méthode 'setupUART' quand le switch est activé
-#           id(clim_sejour).disconnectUART();
-
-#   - platform: template
-#     name: Send 1st packet to ${name}
-#     id: send_packet_switch
-#     entity_category: DIAGNOSTIC
-#     #setup_priority : -100.0 ## late
-#     optimistic: true
-#     turn_on_action:
-#       - lambda: |-          
-#           id(clim_sejour).sendFirstConnectionPacket();    
-  
-#   - platform: template
-#     name: Requests ${name} Synchro
-#     id: build_and_send_requests_info_packets
-#     entity_category: DIAGNOSTIC
-#     #setup_priority : -100.0 ## late
-#     optimistic: true    
-#     turn_on_action:
-#       - lambda: |-          
-#           id(clim_sejour).buildAndSendRequestsInfoPackets(); 

--- a/hp-sejour.yaml
+++ b/hp-sejour.yaml
@@ -8,13 +8,9 @@ esphome:
 
  
 esp8266:
-  board: esp01_1m
+  board: d1_mini
 
-uart:
-  id: HP_UART
-  baud_rate: 2400
-  tx_pin: 1
-  rx_pin: 3
+
 
 mqtt:  
   broker: homeassistant.local
@@ -134,7 +130,12 @@ sensor:
     name: ${name} WiFi Signal
     update_interval: 60s
   
-
+uart:
+  id: HP_UART
+  baud_rate: 2400
+  tx_pin: 1
+  rx_pin: 3
+  
 # Configuration pour l'objet 'climate'
 climate:
   - platform: cn105  # remplis avec la plateforme de ton choix


### PR DESCRIPTION
This is a **major change** to support **ESP-IDF** framework.

The impact is that the user have to configure the uart in a separate section.
Before the modification, the uart was a reference within the climate component section this way:


```yaml
climate:
  - platform: cn105 # remplis avec la plateforme de ton choix
    name: ${friendly_name}
    id: "clim_id"
    baud_rate: 2400
    hardware_uart: UART0
```

Now you have to add an uart section and you can't use baud_rate, tx_pin and rx_pin anymore in the climate section.
You should do this way:


```yaml
uart:
  id: HP_UART
  baud_rate: 2400
  tx_pin: 1
  rx_pin: 3

climate:
  - platform: cn105 
    name: ${friendly_name}
    id: "clim_id"
    update_interval: 2s
```
This forces you to know the pin you are using for the UART communication with the heatpump.


This branch also contains corrections:
- widevane support
- #9 correction  thanks [Bascht74](https://github.com/Bascht74)
