### PR TITLE
Extra components and remote °C timeout

### DIFF
--- a/components/cn105/Globals.h
+++ b/components/cn105/Globals.h
@@ -7,8 +7,8 @@
 #endif
 
 #define CUSTOM_MILLIS ::millis()
-#define MAX_DATA_BYTES     64       // max number of data bytes in incoming messages
-#define MAX_DELAY_RESPONSE_FACTOR 3    // 30 seconds max without response
+#define MAX_DATA_BYTES     64         // max number of data bytes in incoming messages
+#define MAX_DELAY_RESPONSE_FACTOR 10  // update_interval*10 seconds max without response
 
 
 static const char* LOG_ACTION_EVT_TAG = "EVT_SETS";
@@ -212,7 +212,7 @@ struct heatpumpStatus {
     bool operator==(const heatpumpStatus& other) const {
         return roomTemperature == other.roomTemperature &&
             operating == other.operating &&
-            timers == other.timers &&  // Assurez-vous que l'opérateur == est également défini pour heatpumpTimers
+            //timers == other.timers &&  // Assurez-vous que l'opérateur == est également défini pour heatpumpTimers
             compressorFrequency == other.compressorFrequency;
     }
 

--- a/components/cn105/Globals.h
+++ b/components/cn105/Globals.h
@@ -18,6 +18,7 @@ static const char* LOG_STATUS_TAG = "STATUS"; // Logging tag
 
 static const char* SHEDULER_INTERVAL_SYNC_NAME = "hp->sync"; // name of the scheduler to prpgram hp updates
 static const char* DEFER_SHEDULER_INTERVAL_SYNC_NAME = "hp->sync_defer"; // name of the scheduler to prpgram hp updates
+static const char* SHEDULER_REMOTE_TEMP_TIMEOUT = "->remote_temp_timeout";
 
 static const int DEFER_SCHEDULE_UPDATE_LOOP_DELAY = 500;
 static const int PACKET_LEN = 22;

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, uart
-from esphome.components import select
+from esphome.components import climate, uart, select, sensor
+
 from esphome.components.logger import HARDWARE_UART_TO_SERIAL
 from esphome.components.uart import UARTParityOptions
 
@@ -18,20 +18,14 @@ from esphome.core import CORE, coroutine
 AUTO_LOAD = ["climate", "sensor", "select", "binary_sensor", "text_sensor", "uart"]
 
 CONF_SUPPORTS = "supports"
-DEFAULT_CLIMATE_MODES = ["HEAT_COOL", "COOL", "HEAT", "DRY", "FAN_ONLY"]
+# from https://github.com/wrouesnel/esphome-mitsubishiheatpump/blob/master/components/mitsubishi_heatpump/climate.py
+CONF_HORIZONTAL_SWING_SELECT = "horizontal_vane_select"
+CONF_VERTICAL_SWING_SELECT = "vertical_vane_select"
+CONF_COMPRESSOR_FREQUENCY_SENSOR = "compressor_frequency_sensor"
+
+DEFAULT_CLIMATE_MODES = ["COOL", "HEAT", "DRY", "FAN_ONLY"]
 DEFAULT_FAN_MODES = ["AUTO", "QUIET", "LOW", "MEDIUM", "HIGH"]
 DEFAULT_SWING_MODES = ["OFF", "VERTICAL", "HORIZONTAL", "BOTH"]
-
-# from https://github.com/wrouesnel/esphome-mitsubishiheatpump/blob/master/components/mitsubishi_heatpump/climate.py
-# HORIZONTAL_SWING_OPTIONS = [
-#     "AUTO",
-#     "SWING",
-#     "LEFT",
-#     "LEFT_CENTER",
-#     "CENTER",
-#     "RIGHT_CENTER",
-#     "RIGHT",
-# ]
 
 
 # Déclaration des constantes pour TX et RX pin
@@ -39,6 +33,15 @@ CONF_TX_PIN = "tx_pin"
 CONF_RX_PIN = "rx_pin"
 
 CN105Climate = cg.global_ns.class_("CN105Climate", climate.Climate, cg.Component)
+
+
+VaneOrientationSelect = cg.global_ns.class_(
+    "VaneOrientationSelect", select.Select, cg.Component
+)
+
+CompressorFrequencySensor = cg.global_ns.class_(
+    "CompressorFrequencySensor", sensor.Sensor, cg.Component
+)
 
 
 def valid_uart(uart):
@@ -52,6 +55,15 @@ def valid_uart(uart):
     return cv.one_of(*uarts, upper=True)(uart)
 
 
+SELECT_SCHEMA = select.SELECT_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(VaneOrientationSelect)}
+)
+
+SENSOR_SCHEMA = sensor.SENSOR_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(CompressorFrequencySensor)}
+)
+
+
 CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(CN105Climate),
@@ -63,7 +75,10 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
             "'hardware_uart' options is not supported anymore. Please add a separate UART component with the correct rx and tx pin."
         ),
         # cv.Optional(CONF_HARDWARE_UART, default="UART0"): valid_uart,
-        cv.Optional(CONF_UPDATE_INTERVAL, default="0ms"): cv.All(cv.update_interval),
+        cv.Optional(CONF_UPDATE_INTERVAL, default="4s"): cv.All(cv.update_interval),
+        cv.Optional(CONF_HORIZONTAL_SWING_SELECT): SELECT_SCHEMA,
+        cv.Optional(CONF_VERTICAL_SWING_SELECT): SELECT_SCHEMA,
+        cv.Optional(CONF_COMPRESSOR_FREQUENCY_SENSOR): SENSOR_SCHEMA,
         # Optionally override the supported ClimateTraits.
         cv.Optional(CONF_SUPPORTS, default={}): cv.Schema(
             {
@@ -108,6 +123,26 @@ def to_code(config):
 
     for mode in supports[CONF_SWING_MODE]:
         cg.add(traits.add_supported_swing_mode(climate.CLIMATE_SWING_MODES[mode]))
+
+    if CONF_HORIZONTAL_SWING_SELECT in config:
+        conf = config[CONF_HORIZONTAL_SWING_SELECT]
+
+        swing_select = yield select.new_select(conf, options=[])
+        yield cg.register_component(swing_select, conf)
+        cg.add(var.set_horizontal_vane_select(swing_select))
+
+    if CONF_VERTICAL_SWING_SELECT in config:
+        conf = config[CONF_VERTICAL_SWING_SELECT]
+        swing_select = yield select.new_select(conf, options=[])
+        yield cg.register_component(swing_select, conf)
+        cg.add(var.set_vertical_vane_select(swing_select))
+
+    if CONF_COMPRESSOR_FREQUENCY_SENSOR in config:
+        conf = config[CONF_COMPRESSOR_FREQUENCY_SENSOR]
+        conf["force_update"] = False
+        sensor_ = yield sensor.new_sensor(conf)
+        yield cg.register_component(sensor_, conf)
+        cg.add(var.set_compressor_frequency_sensor(sensor_))
 
     yield cg.register_component(var, config)
     yield climate.register_climate(var, config)

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -28,12 +28,9 @@ DEFAULT_FAN_MODES = ["AUTO", "QUIET", "LOW", "MEDIUM", "HIGH"]
 DEFAULT_SWING_MODES = ["OFF", "VERTICAL", "HORIZONTAL", "BOTH"]
 
 
-# Déclaration des constantes pour TX et RX pin
-CONF_TX_PIN = "tx_pin"
-CONF_RX_PIN = "rx_pin"
-
 CN105Climate = cg.global_ns.class_("CN105Climate", climate.Climate, cg.Component)
 
+CONF_REMOTE_TEMP_TIMEOUT = "remote_temperature_timeout"
 
 VaneOrientationSelect = cg.global_ns.class_(
     "VaneOrientationSelect", select.Select, cg.Component
@@ -79,6 +76,7 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_HORIZONTAL_SWING_SELECT): SELECT_SCHEMA,
         cv.Optional(CONF_VERTICAL_SWING_SELECT): SELECT_SCHEMA,
         cv.Optional(CONF_COMPRESSOR_FREQUENCY_SENSOR): SENSOR_SCHEMA,
+        cv.Optional(CONF_REMOTE_TEMP_TIMEOUT, default="never"): cv.update_interval,
         # Optionally override the supported ClimateTraits.
         cv.Optional(CONF_SUPPORTS, default={}): cv.Schema(
             {
@@ -123,6 +121,9 @@ def to_code(config):
 
     for mode in supports[CONF_SWING_MODE]:
         cg.add(traits.add_supported_swing_mode(climate.CLIMATE_SWING_MODES[mode]))
+
+    if CONF_REMOTE_TEMP_TIMEOUT in config:
+        var.set_remote_temp_timeout(config[CONF_REMOTE_TEMP_TIMEOUT])
 
     if CONF_HORIZONTAL_SWING_SELECT in config:
         conf = config[CONF_HORIZONTAL_SWING_SELECT]

--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -1,4 +1,5 @@
 #include "cn105.h"
+#include "Globals.h"
 
 using namespace esphome;
 
@@ -27,6 +28,11 @@ void CN105Climate::checkPendingWantedSettings() {
             this->wantedSettings.hasBeenSent = false;
         }
 
+    } else {
+        if (this->wantedSettings.hasChanged) {
+            ESP_LOGW(TAG, "checkPendingWantedSettings- SHOULDN'T HAPPEN :  this->wantedSettings.hasChanged is true but this->currentSettings == this->wantedSettings,");
+            this->wantedSettings.hasChanged = false;
+        }
     }
 
 }
@@ -87,18 +93,17 @@ void CN105Climate::control(const esphome::climate::ClimateCall& call) {
     // this->publish_state();
 }
 void CN105Climate::controlSwing() {
-    switch (this->swing_mode) {
+    switch (this->swing_mode) {                 //setVaneSetting supports:  AUTO 1 2 3 4 5 and SWING
     case climate::CLIMATE_SWING_OFF:
         this->setVaneSetting("AUTO");
-        //setVaneSetting supports:  AUTO 1 2 3 4 5 and SWING
-        //this->setWideVaneSetting("|");
+        this->setWideVaneSetting("|");
         break;
     case climate::CLIMATE_SWING_VERTICAL:
         this->setVaneSetting("SWING");
-        //this->setWideVaneSetting("|");
+        this->setWideVaneSetting("|");
         break;
     case climate::CLIMATE_SWING_HORIZONTAL:
-        this->setVaneSetting("3");
+        this->setVaneSetting("AUTO");
         this->setWideVaneSetting("SWING");
         break;
     case climate::CLIMATE_SWING_BOTH:
@@ -327,6 +332,20 @@ void CN105Climate::setWideVaneSetting(const char* setting) {
     }
 }
 
+
+void CN105Climate::on_horizontal_swing_change(const std::string& swing) {
+    ESP_LOGD(TAG, "Setting vertical swing position: %s", swing.c_str());
+    //this->setWideVaneSetting(swing.c_str());
+    //this->wantedSettings.hasChanged = true;
+    //this->wantedSettings.hasBeenSent = false;
+}
+
+void CN105Climate::on_vertical_swing_change(const std::string& swing) {
+    ESP_LOGD(TAG, "Setting horizontal swing position: %s", swing.c_str());
+    //this->setVaneSetting(swing.c_str());
+    //this->wantedSettings.hasChanged = true;
+    //this->wantedSettings.hasBeenSent = false;
+}
 
 
 

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -52,6 +52,10 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
     this->tx_pin_ = -1;
     this->rx_pin_ = -1;
 
+    this->horizontal_vane_select_ = nullptr;
+    this->vertical_vane_select_ = nullptr;
+    this->compressor_frequency_sensor_ = nullptr;
+
     this->generateExtraComponents();
 
 }
@@ -110,6 +114,7 @@ void CN105Climate::disconnectUART() {
 
     this->isHeatpumpConnected_ = false;
     this->isConnected_ = false;
+    this->firstRun = true;
     this->cancel_timeout(SHEDULER_INTERVAL_SYNC_NAME);
     this->publish_state();
 

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -56,6 +56,8 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
     this->vertical_vane_select_ = nullptr;
     this->compressor_frequency_sensor_ = nullptr;
 
+    this->remote_temp_timeout_ = 4294967295;    // uint32_t max
+
     this->generateExtraComponents();
 
 }
@@ -74,6 +76,23 @@ void CN105Climate::set_tx_rx_pins(uint8_t tx_pin, uint8_t rx_pin) {
     this->rx_pin_ = rx_pin;
     ESP_LOGI(TAG, "setting tx_pin: %d rx_pin: %d", tx_pin, rx_pin);
 
+}
+
+void CN105Climate::setExternalTemperatureCheckout() {
+    this->set_timeout(SHEDULER_REMOTE_TEMP_TIMEOUT, this->remote_temp_timeout_, [this]() {
+        ESP_LOGW(LOG_ACTION_EVT_TAG, "Remote temperature timeout occured, fall back to internal temperature!");
+        this->set_remote_temperature(0);
+        });
+}
+
+void CN105Climate::set_remote_temp_timeout(uint32_t timeout) {
+    this->remote_temp_timeout_ = timeout;
+    if (timeout == 4294967295) {
+        ESP_LOGI(LOG_ACTION_EVT_TAG, "set_remote_temp_timeout is set to never.");
+    } else {
+        ESP_LOGI(LOG_ACTION_EVT_TAG, "set_remote_temp_timeout is set to %d", timeout);
+        this->setExternalTemperatureCheckout();
+    }
 }
 
 int CN105Climate::get_compressor_frequency() {

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -76,6 +76,11 @@ public:
     // set_remote_temp(0) to switch back to the internal sensor.
     void set_remote_temperature(float);
 
+    void set_remote_temp_timeout(uint32_t timeout);
+
+    // this is the ping or heartbeat of the setRemotetemperature for timeout management
+    void setExternalTemperatureCheckout();
+
     uint32_t get_update_interval() const;
     void set_update_interval(uint32_t update_interval);
 
@@ -194,6 +199,7 @@ private:
 
     unsigned long lastResponseMs;
 
+    uint32_t remote_temp_timeout_;
 
     int baud_ = 0;
     int tx_pin_ = -1;

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -1,24 +1,42 @@
 #pragma once
 #include "Globals.h"
 #include "heatpumpFunctions.h"
+#include "van_orientation_select.h"
 
 using namespace esphome;
 
-class VaneOrientationSelect;  // Déclaration anticipée, définie dans extraComponents
+//class VaneOrientationSelect;  // Déclaration anticipée, définie dans extraComponents
 
 
 
 class CN105Climate : public climate::Climate, public Component, public uart::UARTDevice {
 
-    friend class VaneOrientationSelect;
+    //friend class VaneOrientationSelect;
 
 public:
 
     CN105Climate(uart::UARTComponent* hw_serial);
 
-    sensor::Sensor* compressor_frequency_sensor;
+
+    void set_vertical_vane_select(VaneOrientationSelect* vertical_vane_select);
+    void set_horizontal_vane_select(VaneOrientationSelect* horizontal_vane_select);
+    void set_compressor_frequency_sensor(esphome::sensor::Sensor* compressor_frequency_sensor);
+
+    //sensor::Sensor* compressor_frequency_sensor;
     binary_sensor::BinarySensor* iSee_sensor;
-    select::Select* van_orientation;
+    //select::Select* van_orientation;
+
+
+    VaneOrientationSelect* vertical_vane_select_ =
+        nullptr;  // Select to store manual position of vertical swing
+    VaneOrientationSelect* horizontal_vane_select_ =
+        nullptr;  // Select to store manual position of horizontal swing
+    sensor::Sensor* compressor_frequency_sensor_ =
+        nullptr;  // Sensor to store compressor frequency
+
+    // When received command to change the vane positions
+    void on_horizontal_swing_change(const std::string& swing);
+    void on_vertical_swing_change(const std::string& swing);
 
     //text_sensor::TextSensor* last_sent_packet_sensor;
     //text_sensor::TextSensor* last_received_packet_sensor;
@@ -98,6 +116,8 @@ public:
         return (int)(temp + 0.5);
     }
 
+    const char* getIfNotNull(const char* what, const char* defaultValue);
+
 protected:
     // HeatPump object using the underlying Arduino library.
     // same as PolingComponent
@@ -115,6 +135,10 @@ protected:
     void initBytePointer();
     void processDataPacket();
     void getDataFromResponsePacket();
+    void getSettingsFromResponsePacket();
+    void getRoomTemperatureFromResponsePacket();
+    void getOperatingAndCompressorFreqFromResponsePacket();
+
     void programUpdateInterval();
     void updateSuccess();
     void processCommand();
@@ -150,6 +174,7 @@ private:
     void checkPowerAndModeSettings(heatpumpSettings& settings);
     void checkFanSettings(heatpumpSettings& settings);
     void checkVaneSettings(heatpumpSettings& settings);
+    void updateExtraSelectComponents(heatpumpSettings& settings);
 
     void statusChanged();
     void updateAction();

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -16,20 +16,7 @@ void CN105Climate::setup() {
     this->fan_mode = climate::CLIMATE_FAN_OFF;
     this->swing_mode = climate::CLIMATE_SWING_OFF;
     this->initBytePointer();
-
-    /* ESP_LOGI(
-         TAG,
-         "hw_serial(%p) is &Serial(%p)? %s",
-         this->get_hw_serial_(),
-         &Serial,
-         YESNO(this->get_hw_serial_() == &Serial)
-     );*/
-
-    ESP_LOGI(TAG, "bauds: %d", this->baud_);
-
-    //check_logger_conflict_ is called from the UART abstraction
-    //this->check_logger_conflict_();
-
+    this->lastResponseMs = CUSTOM_MILLIS;
     this->setupUART();
     this->sendFirstConnectionPacket();
 }

--- a/components/cn105/compressor_frequency_sensor.h
+++ b/components/cn105/compressor_frequency_sensor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+
+
+namespace esphome {
+
+    class CompressorFrequencySensor : public sensor::Sensor, public Component {
+    public:
+        CompressorFrequencySensor() {
+            this->set_unit_of_measurement("Hz");
+            this->set_accuracy_decimals(0);
+        }
+
+
+
+    };
+
+}

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -1,8 +1,7 @@
 #include "cn105.h"
 
 using namespace esphome;
-
-
+/*
 class VaneOrientationSelect : public select::Select {
 public:
     VaneOrientationSelect(CN105Climate* parent) : parent_(parent) {}
@@ -14,38 +13,38 @@ public:
         parent_->setVaneSetting(value.c_str()); // should be enough to trigger a sendWantedSettings
         parent_->wantedSettings.hasChanged = true;
         parent_->wantedSettings.hasBeenSent = false;
-        // now updated thanks to new sendWantedSettings policy 
+        // now updated thanks to new sendWantedSettings policy
         // parent_->sendWantedSettings();
 
     }
 private:
     CN105Climate* parent_;
 
-};
+};*/
 
 void CN105Climate::generateExtraComponents() {
-    this->compressor_frequency_sensor = new sensor::Sensor();
+    /*this->compressor_frequency_sensor = new sensor::Sensor();
     this->compressor_frequency_sensor->set_name("Compressor Frequency");
     this->compressor_frequency_sensor->set_unit_of_measurement("Hz");
     this->compressor_frequency_sensor->set_accuracy_decimals(0);
     this->compressor_frequency_sensor->publish_state(0);
 
     // Enregistrer le capteur pour que ESPHome le gère
-    App.register_sensor(compressor_frequency_sensor);
+    App.register_sensor(compressor_frequency_sensor);*/
 
     this->iSee_sensor = new binary_sensor::BinarySensor();
     this->iSee_sensor->set_name("iSee sensor");
     this->iSee_sensor->publish_initial_state(false);
     App.register_binary_sensor(this->iSee_sensor);
 
-    this->van_orientation = new  VaneOrientationSelect(this);
+    /*this->van_orientation = new  VaneOrientationSelect(this);
     this->van_orientation->set_name("Van orientation");
 
-    //this->van_orientation->traits.set_options({ "AUTO", "1", "2", "3", "4", "5", "SWING" });    
+    //this->van_orientation->traits.set_options({ "AUTO", "1", "2", "3", "4", "5", "SWING" });
     std::vector<std::string> vaneOptions(std::begin(VANE_MAP), std::end(VANE_MAP));
     this->van_orientation->traits.set_options(vaneOptions);
 
-    App.register_select(this->van_orientation);
+    App.register_select(this->van_orientation);*/
 
     /*this->last_sent_packet_sensor = new TextSensor();
     this->last_sent_packet_sensor->set_name("Last Sent Packet");
@@ -59,4 +58,58 @@ void CN105Climate::generateExtraComponents() {
     App.register_text_sensor(this->last_received_packet_sensor);*/
 
 
+}
+
+void CN105Climate::set_vertical_vane_select(
+    VaneOrientationSelect* vertical_vane_select) {
+
+    this->vertical_vane_select_ = vertical_vane_select;
+
+    // builds option list from SwiCago vaneMap
+    std::vector<std::string> vaneOptions(std::begin(VANE_MAP), std::end(VANE_MAP));
+    this->vertical_vane_select_->traits.set_options(vaneOptions);
+
+    this->vertical_vane_select_->setCallbackFunction([this](const char* setting) {
+
+        ESP_LOGD("EVT", "vane.control() -> Demande un chgt de réglage de la vane: %s", setting);
+
+        this->setVaneSetting(setting);
+        this->wantedSettings.hasChanged = true;
+        this->wantedSettings.hasBeenSent = false;
+        });
+
+    /*this->vertical_vane_select_->add_on_state_callback(
+        [this](const std::string& value, size_t index) {
+            //if (value == this->vertical_swing_state_) return;
+            this->on_vertical_swing_change(value);
+        });*/
+}
+
+void CN105Climate::set_horizontal_vane_select(
+    VaneOrientationSelect* horizontal_vane_select) {
+    this->horizontal_vane_select_ = horizontal_vane_select;
+
+    // builds option list from SwiCago wideVaneMap
+    std::vector<std::string> wideVaneOptions(std::begin(WIDEVANE_MAP), std::end(WIDEVANE_MAP));
+    this->horizontal_vane_select_->traits.set_options(wideVaneOptions);
+
+    this->horizontal_vane_select_->setCallbackFunction([this](const char* setting) {
+
+        ESP_LOGD("EVT", "wideVane.control() -> Demande un chgt de réglage de la wideVane: %s", setting);
+
+        this->setWideVaneSetting(setting);
+        this->wantedSettings.hasChanged = true;
+        this->wantedSettings.hasBeenSent = false;
+        });
+
+    /*this->horizontal_vane_select_->add_on_state_callback(
+        [this](const std::string& value, size_t index) {
+            //if (value == this->horizontal_swing_state_) return;
+            this->on_horizontal_swing_change(value);
+        });*/
+}
+
+void CN105Climate::set_compressor_frequency_sensor(
+    sensor::Sensor* compressor_frequency_sensor) {
+    this->compressor_frequency_sensor_ = compressor_frequency_sensor;
 }

--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -371,4 +371,7 @@ void CN105Climate::set_remote_temperature(float setting) {
     writePacket(packet, PACKET_LEN);
     // optimistic
     this->currentStatus.roomTemperature = setting;
+
+    // this resets the timeout
+    this->setExternalTemperatureCheckout();
 }

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -44,7 +44,7 @@ const char* CN105Climate::getIfNotNull(const char* what, const char* defaultValu
 
 void CN105Climate::debugSettings(const char* settingName, wantedHeatpumpSettings settings) {
 #ifdef USE_ESP32
-    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%s]-> [power: %s, target °C: %2f, mode: %s, fan: %s, vane: %s, wvane: %s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
+    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%s]-> [power: %s, target °C: %.1f, mode: %s, fan: %s, vane: %s, wvane: %s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
         getIfNotNull(settingName, "unnamed"),
         getIfNotNull(settings.power, "-"),
         settings.temperature,
@@ -56,7 +56,7 @@ void CN105Climate::debugSettings(const char* settingName, wantedHeatpumpSettings
         settings.hasBeenSent ? "YES" : " NO"
     );
 #else
-    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%-*s]-> [power: %-*s, target °C: %2f, mode: %-*s, fan: %-*s, vane: %-*s, wvane: %-*s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
+    ESP_LOGI(LOG_ACTION_EVT_TAG, "[%-*s]-> [power: %-*s, target °C: %.1f, mode: %-*s, fan: %-*s, vane: %-*s, wvane: %-*s, hasChanged ? -> %s, hasBeenSent ? -> %s]",
         15, getIfNotNull(settingName, "unnamed"),
         3, getIfNotNull(settings.power, "-"),
         settings.temperature,
@@ -72,7 +72,7 @@ void CN105Climate::debugSettings(const char* settingName, wantedHeatpumpSettings
 
 void CN105Climate::debugSettings(const char* settingName, heatpumpSettings settings) {
 #ifdef USE_ESP32
-    ESP_LOGI(LOG_SETTINGS_TAG, "[%s]-> [power: %s, target °C: %2f, mode: %s, fan: %s, vane: %s, wvane: %s]",
+    ESP_LOGI(LOG_SETTINGS_TAG, "[%s]-> [power: %s, target °C: %.1f, mode: %s, fan: %s, vane: %s, wvane: %s]",
         getIfNotNull(settingName, "unnamed"),
         getIfNotNull(settings.power, "-"),
         settings.temperature,
@@ -82,7 +82,7 @@ void CN105Climate::debugSettings(const char* settingName, heatpumpSettings setti
         getIfNotNull(settings.wideVane, "-")
     );
 #else
-    ESP_LOGI(LOG_SETTINGS_TAG, "[%-*s]-> [power: %-*s, target °C: %2f, mode: %-*s, fan: %-*s, vane: %-*s, wvane: %-*s]",
+    ESP_LOGI(LOG_SETTINGS_TAG, "[%-*s]-> [power: %-*s, target °C: %.1f, mode: %-*s, fan: %-*s, vane: %-*s, wvane: %-*s]",
         15, getIfNotNull(settingName, "unnamed"),
         3, getIfNotNull(settings.power, "-"),
         settings.temperature,

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -35,7 +35,7 @@ bool CN105Climate::isWantedSettingApplied(const char* wantedSettingProp, const c
 }
 
 
-const char* getIfNotNull(const char* what, const char* defaultValue) {
+const char* CN105Climate::getIfNotNull(const char* what, const char* defaultValue) {
     if (what == NULL) {
         return defaultValue;
     }

--- a/components/cn105/van_orientation_select.h
+++ b/components/cn105/van_orientation_select.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "esphome/components/select/select.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+
+    class VaneOrientationSelect : public select::Select, public Component {
+    public:
+
+        using CallbackFunction = std::function<void(const char* setting)>;
+
+
+        void setCallbackFunction(CallbackFunction&& callback) {
+            this->callBackFunction = std::move(callback);
+
+        }
+
+
+    protected:
+        void control(const std::string& value) override {
+            if (callBackFunction) {
+                callBackFunction(value.c_str()); // should be enough to trigger a sendWantedSettings
+            }
+        }
+
+    private:
+        CallbackFunction callBackFunction;
+
+    };
+
+}  // namespace esphome

--- a/esp32-test.yaml
+++ b/esp32-test.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  name: "hpsejour"
-  friendly_name: Climatisation Séjour
+  name: "esp32-hp"
+  friendly_name: ESP32 Climatisation
 
 esphome:
   name: ${name}
@@ -13,30 +13,33 @@ esp32:
     #type: arduino
 
 
-  
-    
-
-# mqtt:  
-#   broker: 10.1.101.172
-#   username: heatpumpSejour
-#   password: !secret mqtt_password
-#   discovery: true
+mqtt:  
+  broker: homeassistant.local
+  username: heatpumpSejour
+  password: !secret mqtt_password
+  discovery: true
   
 
 # Enable logging
-logger:  
-  hardware_uart: UART0
-  level: VERBOSE
-  # logs:
-  #   CN105Climate: WARN
-  #   CN105: WARN
-  #   climate: WARN
-  #   sensor: WARN
-  #   chkSum : INFO
-  #   WRITE : WARN
-  #   READ : WARN
-  #   Header: INFO
-  #   Decoder : WARN
+logger:    
+  level: INFO
+  logs:
+    EVT_SETS : INFO
+    WIFI : INFO
+    MQTT : INFO
+    WRITE_SETTINGS : INFO
+    SETTINGS : INFO
+    STATUS : INFO
+    CN105Climate: WARN
+    CN105: INFO
+    climate: WARN
+    sensor: WARN
+    chkSum : INFO
+    WRITE : WARN
+    READ : WARN
+    Header: INFO
+    Decoder : INFO
+    CONTROL_WANTED_SETTINGS: INFO
     
 
 # Enable Home Assistant API
@@ -46,11 +49,11 @@ api:
       variables:
         temperature: float
       then:
-        - lambda: 'id(clim_sejour).set_remote_temperature(temperature);'
+        - lambda: 'id(esp32_clim).set_remote_temperature(temperature);'
 
     - service: use_internal_temperature
       then:
-        - lambda: 'id(clim_sejour).set_remote_temperature(0);'
+        - lambda: 'id(esp32_clim).set_remote_temperature(0);'
   encryption:
     key: !secret encryption_key
 
@@ -127,7 +130,7 @@ sensor:
   #   name: Operating (Clim)
   #   update_interval: 10s
   #   lambda: |-
-  #     return(id(clim_sejour).is_operating());
+  #     return(id(esp32_clim).is_operating());
   
   # Etat de l'attribut compressor°frequency décodé dans les trames de réponse du clim
   # généré dynamiquement dans le code de la clim
@@ -135,19 +138,19 @@ sensor:
   #   name: Compressor Frequency (Clim)
   #   update_interval: 10s
   #   lambda: |-
-  #     return(id(clim_sejour).get_compressor_frequency());
+  #     return(id(esp32_clim).get_compressor_frequency());
 
 uart:
   id: HP_UART
   baud_rate: 2400
-  tx_pin: 1
-  rx_pin: 3
+  tx_pin: GPIO17
+  rx_pin: GPIO16
 
 # Configuration pour l'objet 'climate'
 climate:
   - platform: cn105  # remplis avec la plateforme de ton choix
     name: ${friendly_name}
-    id: "clim_sejour"
+    id: "esp32_clim"
     # baud_rate: 2400
     # hardware_uart: UART1
     update_interval: 10s         # shouldn't be less than 4 seconds
@@ -165,11 +168,11 @@ climate:
 #     turn_on_action:
 #       - lambda: |-
 #           // Appelle la méthode 'setupUART' quand le switch est activé
-#           id(clim_sejour).setupUART();
+#           id(esp32_clim).setupUART();
 #     turn_off_action:
 #       - lambda: |-
 #           // Appelle la méthode 'setupUART' quand le switch est activé
-#           id(clim_sejour).disconnectUART();
+#           id(esp32_clim).disconnectUART();
 
 #   - platform: template
 #     name: Send 1st packet to ${name}
@@ -179,7 +182,7 @@ climate:
 #     optimistic: true
 #     turn_on_action:
 #       - lambda: |-          
-#           id(clim_sejour).sendFirstConnectionPacket();    
+#           id(esp32_clim).sendFirstConnectionPacket();    
   
 #   - platform: template
 #     name: Requests ${name} Synchro
@@ -189,4 +192,4 @@ climate:
 #     optimistic: true    
 #     turn_on_action:
 #       - lambda: |-          
-#           id(clim_sejour).buildAndSendRequestsInfoPackets(); 
+#           id(esp32_clim).buildAndSendRequestsInfoPackets(); 

--- a/esp32-test.yaml
+++ b/esp32-test.yaml
@@ -18,11 +18,17 @@ mqtt:
   username: heatpumpSejour
   password: !secret mqtt_password
   discovery: true
-  
+
+
+
+debug:
+  update_interval: 5s
+
+
 
 # Enable logging
 logger:    
-  level: INFO
+  level: DEBUG
   logs:
     EVT_SETS : INFO
     WIFI : INFO
@@ -45,6 +51,12 @@ logger:
 # Enable Home Assistant API
 api:
   services:    
+    - service: reboot
+      then:
+        - logger.log: "Redémarrage en cours..."
+        - lambda: |-
+            esp_restart();
+
     - service: set_remote_temperature
       variables:
         temperature: float
@@ -114,8 +126,28 @@ text_sensor:
     bssid:
       name: ${name} BSSID
 
+  - platform: debug
+    device:
+      name: "Device Info"
+    reset_reason:
+      name: "Reset Reason"
+
+
 # Sensors with general information.
 sensor:
+  - platform: debug
+    free:
+      name: "Heap Free"
+    # fragmentation:
+    #   name: "Heap Fragmentation"
+    # block:
+    #   name: "Heap Max Block"
+    # loop_time:
+    #   name: "Loop Time"
+    # psram:
+    #   name: "Free PSRAM"
+
+
   # Uptime sensor.
   - platform: uptime
     name: ${name} Uptime
@@ -148,6 +180,11 @@ climate:
     id: "esp32_clim"
     compressor_frequency_sensor:
       name: Compressor frequency (clim Sejour)    
+    vertical_vane_select:
+      name: Orientation de la Vane Verticale
+    horizontal_vane_select:
+      name: Orientation de la Vane Horizontale
+    
     update_interval: 10s         # shouldn't be less than 1 second
     
 

--- a/esp32-test.yaml
+++ b/esp32-test.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: "esp32-hp"
-  friendly_name: ESP32 Climatisation
+  friendly_name: Clim Sejour
 
 esphome:
   name: ${name}
@@ -124,21 +124,17 @@ sensor:
   - platform: wifi_signal
     name: ${name} WiFi Signal
     update_interval: 60s
-  
-  # Etat de l'attribut operating décodé dans les trames de réponse du clim
-  # - platform: template
-  #   name: Operating (Clim)
-  #   update_interval: 10s
-  #   lambda: |-
-  #     return(id(esp32_clim).is_operating());
-  
-  # Etat de l'attribut compressor°frequency décodé dans les trames de réponse du clim
-  # généré dynamiquement dans le code de la clim
-  # - platform: template
-  #   name: Compressor Frequency (Clim)
-  #   update_interval: 10s
-  #   lambda: |-
-  #     return(id(esp32_clim).get_compressor_frequency());
+
+  - platform: homeassistant
+    id: ha_cdeg_sejour_et_cuisine
+    entity_id: sensor.cdeg_sejour_et_cuisine
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            id(esp32_clim).set_remote_temperature(x);
+
+          
 
 uart:
   id: HP_UART
@@ -146,15 +142,14 @@ uart:
   tx_pin: GPIO17
   rx_pin: GPIO16
 
-# Configuration pour l'objet 'climate'
 climate:
-  - platform: cn105  # remplis avec la plateforme de ton choix
+  - platform: cn105  
     name: ${friendly_name}
     id: "esp32_clim"
-    # baud_rate: 2400
-    # hardware_uart: UART1
-    update_interval: 10s         # shouldn't be less than 4 seconds
-    # Ajoute d'autres paramètres spécifiques à ton matériel et tes besoins
+    compressor_frequency_sensor:
+      name: Compressor frequency (clim Sejour)    
+    update_interval: 10s         # shouldn't be less than 1 second
+    
 
 
 # Configuration pour l'objet 'switch' (bouton)

--- a/esp32-test.yaml
+++ b/esp32-test.yaml
@@ -184,7 +184,7 @@ climate:
       name: Orientation de la Vane Verticale
     horizontal_vane_select:
       name: Orientation de la Vane Horizontale
-    
+    remote_temperature_timeout: 30min
     update_interval: 10s         # shouldn't be less than 1 second
     
 

--- a/hp-sejour.yaml
+++ b/hp-sejour.yaml
@@ -12,24 +12,24 @@ esp8266:
 
 
 
-mqtt:  
-  broker: homeassistant.local
-  username: heatpumpSejour
-  password: !secret mqtt_password
-  discovery: true
+# mqtt:  
+#   broker: homeassistant.local
+#   username: heatpumpSejour
+#   password: !secret mqtt_password
+#   discovery: true
 
 
 
 # Enable logging
 logger:  
   hardware_uart: UART1
-  level: DEBUG
+  level: INFO
   logs:
-    EVT_SETS : DEBUG
+    EVT_SETS : INFO
     WIFI : INFO
     MQTT : INFO
-    WRITE_SETTINGS : DEBUG
-    SETTINGS : DEBUG
+    WRITE_SETTINGS : INFO
+    SETTINGS : INFO
     STATUS : INFO
     CN105Climate: WARN
     CN105: INFO
@@ -39,8 +39,26 @@ logger:
     WRITE : WARN
     READ : WARN
     Header: INFO
-    Decoder : WARN
-    CONTROL_WANTED_SETTINGS: DEBUG
+    Decoder : INFO
+    CONTROL_WANTED_SETTINGS: INFO
+  # level: DEBUG
+  # logs:
+  #   EVT_SETS : DEBUG
+  #   WIFI : INFO
+  #   MQTT : INFO
+  #   WRITE_SETTINGS : DEBUG
+  #   SETTINGS : DEBUG
+  #   STATUS : INFO
+  #   CN105Climate: WARN
+  #   CN105: DEBUG
+  #   climate: WARN
+  #   sensor: WARN
+  #   chkSum : INFO
+  #   WRITE : WARN
+  #   READ : WARN
+  #   Header: INFO
+  #   Decoder : DEBUG
+  #   CONTROL_WANTED_SETTINGS: DEBUG
 
 # Enable Home Assistant API
 api:
@@ -141,6 +159,48 @@ climate:
   - platform: cn105  # remplis avec la plateforme de ton choix
     name: ${friendly_name}
     id: "clim_sejour"    
-    update_interval: 10s         # shouldn't be less than 1 second
-    # Ajoute d'autres paramètres spécifiques à ton matériel et tes besoins
+    update_interval: 2s         # shouldn't be less than 1 second
+    # horizontal_vane_select:
+    #   name: ${name} Horizontal Vane
+    #   id: "clim_sejour_horizontal_vane"
+    vertical_vane_select:
+      name: ${name} Vertical Vane
+      id: "clim_sejour_vertical_vane"
+    compressor_frequency_sensor:
+      name: ${name} Compressor Frequency
+      id: "clim_sejour_compressor_frequency"
+    
+    # Configuration pour l'objet 'switch' (bouton)
+switch:
+  - platform: template
+    name: ${name} UART Setup Switch
+    id: uart_setup_switch
+    #setup_priority : -100.0 ## late
+    optimistic: true
+    turn_on_action:
+      - lambda: |-
+          // Appelle la méthode 'setupUART' quand le switch est activé
+          id(clim_sejour).setupUART();
+    turn_off_action:
+      - lambda: |-
+          // Appelle la méthode 'setupUART' quand le switch est activé
+          id(clim_sejour).disconnectUART();
+
+  - platform: template
+    name: Send 1st packet to ${name}
+    id: send_packet_switch
+    #setup_priority : -100.0 ## late
+    optimistic: true
+    turn_on_action:
+      - lambda: |-          
+          id(clim_sejour).sendFirstConnectionPacket();    
+  
+  # - platform: template
+  #   name: Requests ${name} Synchro
+  #   id: build_and_send_requests_info_packets
+  #   #setup_priority : -100.0 ## late
+  #   optimistic: true    
+  #   turn_on_action:
+  #     - lambda: |-          
+  #         id(clim_sejour).buildAndSendRequestsInfoPackets(); 
 


### PR DESCRIPTION
This pull request to merge the recent work on asked features:

- horizontal and horizontal vanes select with custom names.
- same for compressor frequency sensor.
- timeout for external temperature provider

```yaml
climate:
  - platform: cn105  
    name: ${friendly_name}
    id: "esp32_clim"
    # add an extra select component for compressor
    compressor_frequency_sensor:
      name: Compressor frequency (clim Sejour)    
    # add an extra select component for vertical vane
    vertical_vane_select:
      name: Orientation de la Vane Verticale
    # add an extra select component for horizontal vane
    horizontal_vane_select:
      name: Orientation de la Vane Horizontale
    # set a timeout on external temp to fall back on internal temperature 
    # if no temperature is provided for a too long period
    remote_temperature_timeout: 30min
    update_interval: 10s  
```

