### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.DS_Store
+.vscode
+components/cn105/.DS_Store
+components/.DS_Store
+esp01-test.yaml
+.esphome
+__pycache__
+hp-chambres.yaml
+hp-preflash.yml
+hp-seb.yaml
+secrets.yaml
+components/.DS_Store


### PR DESCRIPTION
# Committing .gitignore to the Repository

This commit includes the `.gitignore` file in our repository. The purpose of this file is to ensure that certain files and directories (like system-specific files, build outputs, temporary files, etc.) are not tracked by Git. By including `.gitignore` in the repository, we ensure a consistent Git experience for all contributors, preventing the accidental addition of unwanted files. This is particularly important in a collaborative environment, as it helps maintain a clean and manageable codebase. It also aids in avoiding conflicts and clutter that can arise from platform-specific or user-specific files (such as `.DS_Store` files on macOS, or IDE-specific directories like `.vscode`). Keeping `.gitignore` in the repository is a best practice for version control and contributes to the overall health and efficiency of our project's development process.