### PR TITLE
Logger spam if unable to connect to the heatpump  #56

### DIFF
--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -14,7 +14,6 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
     this->traits_.set_visual_max_temperature(ESPMHP_MAX_TEMPERATURE);
     this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
 
-
     this->isConnected_ = false;
     this->tempMode = false;
     this->wideVaneAdj = false;

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -42,7 +42,6 @@ void CN105Climate::loop() {
                 this->loopCycle.checkTimeout(this->update_interval_);
             } else { // we are not running a cycle
                 if (this->loopCycle.hasUpdateIntervalPassed(this->get_update_interval())) {
-                    ESP_LOGD(LOG_UPD_INT_TAG, "triggering infopacket because of update interval tick");
                     this->buildAndSendRequestsInfoPackets();            // initiate an update cycle with this->cycleStarted();
                 }
             }


### PR DESCRIPTION
* changes timeout after sendFirstConnectionPacket() from 4s to 10s.
* calls  sendFirstConnectionPacket() again at timeout
* removed (or moved) spam logs