### PR TITLE
Fix uptime_sensor.h: No such file or directory 

### DIFF
--- a/components/cn105/uptime_connection_sensor.cpp
+++ b/components/cn105/uptime_connection_sensor.cpp
@@ -9,7 +9,7 @@ namespace esphome {
         static const char* const TAG = "uptime.connection.sensor";
         void HpUpTimeConnectionSensor::update() {
             if (connected_) {
-                UptimeSensor::update();
+                UptimeSecondsSensor::update();
             } else {
                 this->uptime_ = 0;
                 this->publish_state(0);

--- a/components/cn105/uptime_connection_sensor.h
+++ b/components/cn105/uptime_connection_sensor.h
@@ -1,10 +1,10 @@
 #pragma once
-#include "esphome/components/uptime/uptime_sensor.h"
+#include "esphome/components/uptime/uptime_seconds_sensor.h"
 
 namespace esphome {
     namespace uptime {
 
-        class HpUpTimeConnectionSensor : public UptimeSensor {
+        class HpUpTimeConnectionSensor : public UptimeSecondsSensor {
         public:
             void update() override;
             std::string unique_id() override;


### PR DESCRIPTION
Hey,

Following https://github.com/esphome/esphome/pull/7029, uptime_sensor was changed to uptime_seconds_sensor

This PR fixes https://github.com/echavet/MitsubishiCN105ESPHome/issues/131