### PR TITLE
ci: Add GitHub Actions Workflow to test build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,42 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        version: [dev, 2024.8]
+        variant: [esp32-test, hp-debug]
+    container:
+      image: ghcr.io/esphome/esphome:${{ matrix.version }}
+    env:
+      USERNAME: test
+      PASSWORD: github-run
+    steps:
+    - uses: actions/checkout@v4
+    - name: Generate random secret
+      env:
+        keys: >-
+          mqtt_password ota_pwd
+          wifi_ssid wifi_password wifi_ssid3 wifi_password3
+        enc_keys: encryption_key_sejour encryption_key
+      run: |
+        for key in $keys ; do
+          value=`head -c 100 /dev/urandom | base64 | cut -c 1-24 | head -n1`
+          echo "${key}: ${value}" >> secrets.yaml
+        done
+        for key in $enc_keys ; do
+          value=`head -c 32 /dev/urandom | base64`
+          echo "${key}: ${value}" >> secrets.yaml
+        done
+    - run: esphome compile ${{ matrix.variant }}.yaml

--- a/hp-debug.yaml
+++ b/hp-debug.yaml
@@ -50,6 +50,7 @@ api:
     key: !secret encryption_key
 
 ota:  
+- platform: esphome
   password: !secret ota_pwd
 
 wifi:
@@ -115,13 +116,17 @@ text_sensor:
 #    name: ${name} WiFi Signal
 #    update_interval: 60s
 
+uart:
+  id: HP_UART
+  baud_rate: 2400
+  tx_pin: GPIO1
+  rx_pin: GPIO3
+
 # Configuration pour l'objet 'climate'
 climate:
   - platform: cn105  # remplis avec la plateforme de ton choix
     name: "Clim Seb"
     id: "clim_seb"
-    baud_rate: 0
-    hardware_uart: UART0
     update_interval: 4s
     # Ajoute d'autres paramètres spécifiques à ton matériel et tes besoins
     
@@ -196,4 +201,4 @@ switch:
     optimistic: true    
     turn_on_action:
       - lambda: |-          
-          id(clim_seb).buildAndSendRequestsInfoPackets(); 
+          id(clim_seb).buildAndSendRequestsInfoPackets();

--- a/hp-sejour.yaml
+++ b/hp-sejour.yaml
@@ -81,8 +81,8 @@ api:
     key: !secret encryption_key
 
 ota:  
+- platform: esphome
   password: !secret ota_pwd
-  platform: esphome
 wifi:
   #ssid: !secret wifi_ssid
   #password: !secret wifi_password


### PR DESCRIPTION
Builds the project with latest `dev` version of **esphome**, and a stable version set.
Concurrent builds are limited due to rate-limit while pulling container image.