### PR TITLE
Add support for compressor frequency in 16-bit format with 1 decimal.

### DIFF
--- a/components/cn105/Globals.h
+++ b/components/cn105/Globals.h
@@ -189,7 +189,7 @@ struct wantedHeatpumpSettings : heatpumpSettings {
         hasChanged = false;
         hasBeenSent = false;
         //nb_deffered_requests = 0;
-        //lastChange = 0; 
+        //lastChange = 0;
     }
 
     wantedHeatpumpSettings& operator=(const wantedHeatpumpSettings& other) {
@@ -203,7 +203,7 @@ struct wantedHeatpumpSettings : heatpumpSettings {
 
     wantedHeatpumpSettings& operator=(const heatpumpSettings& other) {
         if (this != &other) { // self-assignment protection
-            heatpumpSettings::operator=(other); // Copie des membres de base                        
+            heatpumpSettings::operator=(other); // Copie des membres de base
         }
         return *this;
     }
@@ -246,7 +246,7 @@ struct heatpumpStatus {
     float roomTemperature;
     bool operating; // if true, the heatpump is operating to reach the desired temperature
     heatpumpTimers timers;
-    int compressorFrequency;
+    float compressorFrequency;
 
     bool operator==(const heatpumpStatus& other) const {
         return roomTemperature == other.roomTemperature &&

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -36,7 +36,7 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
 
     this->powerRequestWithoutResponses = 0;     // power request is not supported by all heatpump #112
 
-    this->remote_temp_timeout_ = 4294967295;    // uint32_t max    
+    this->remote_temp_timeout_ = 4294967295;    // uint32_t max
     this->generateExtraComponents();
     this->loopCycle.init();
     this->wantedSettings.resetSettings();
@@ -71,7 +71,7 @@ void CN105Climate::set_remote_temp_timeout(uint32_t timeout) {
     if (timeout == 4294967295) {
         ESP_LOGI(LOG_ACTION_EVT_TAG, "set_remote_temp_timeout is set to never.");
     } else {
-        //ESP_LOGI(LOG_ACTION_EVT_TAG, "set_remote_temp_timeout is set to %lu", timeout);        
+        //ESP_LOGI(LOG_ACTION_EVT_TAG, "set_remote_temp_timeout is set to %lu", timeout);
         log_info_uint32(LOG_ACTION_EVT_TAG, "set_remote_temp_timeout is set to ", timeout);
 
         this->pingExternalTemperature();
@@ -84,7 +84,7 @@ void CN105Climate::set_debounce_delay(uint32_t delay) {
     log_info_uint32(LOG_ACTION_EVT_TAG, "set_debounce_delay is set to ", delay);
 }
 
-int CN105Climate::get_compressor_frequency() {
+float CN105Climate::get_compressor_frequency() {
     return currentStatus.compressorFrequency;
 }
 bool CN105Climate::is_operating() {
@@ -173,9 +173,8 @@ bool CN105Climate::isHeatpumpConnectionActive() {
     // if (lrTimeMs > MAX_DELAY_RESPONSE_FACTOR * this->update_interval_) {
     //     ESP_LOGV(TAG, "Heatpump has not replied for %ld s", lrTimeMs / 1000);
     //     ESP_LOGV(TAG, "We think Heatpump is not connected anymore..");
-    //     this->disconnectUART();        
+    //     this->disconnectUART();
     // }
 
     return  (lrTimeMs < MAX_DELAY_RESPONSE_FACTOR * this->update_interval_);
 }
-

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -55,10 +55,10 @@ public:
     sensor::Sensor* compressor_frequency_sensor_ =
         nullptr;  // Sensor to store compressor frequency
 
-    // sensor to monitor heatpump connection time 
+    // sensor to monitor heatpump connection time
     uptime::HpUpTimeConnectionSensor* hp_uptime_connection_sensor_ = nullptr;
 
-    int get_compressor_frequency();
+    float get_compressor_frequency();
     bool is_operating();
 
     // checks if the field has changed

--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -51,7 +51,7 @@ void CN105Climate::sendFirstConnectionPacket() {
 
 //     ESP_LOGD(TAG, "t°: %f", currentStatus.roomTemperature);
 //     ESP_LOGD(TAG, "operating: %d", currentStatus.operating);
-//     ESP_LOGD(TAG, "compressor freq: %d", currentStatus.compressorFrequency);
+//     ESP_LOGD(TAG, "compressor freq: %f", currentStatus.compressorFrequency);
 
 //     this->updateAction();
 //     this->publish_state();
@@ -275,10 +275,10 @@ void CN105Climate::sendWantedSettings() {
 #ifdef USE_ESP32
             std::lock_guard<std::mutex> guard(wantedSettingsMutex);
             this->sendWantedSettingsDelegate();
-#else            
+#else
             this->emulateMutex("WRITE_SETTINGS", std::bind(&CN105Climate::sendWantedSettingsDelegate, this));
 
-#endif                
+#endif
 
         } else {
             ESP_LOGD(TAG, "will sendWantedSettings later because we've sent one too recently...");

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -125,13 +125,13 @@ void CN105Climate::debugSettings(const char* settingName, heatpumpSettings setti
 
 void CN105Climate::debugStatus(const char* statusName, heatpumpStatus status) {
 #ifdef USE_ESP32
-    ESP_LOGI(LOG_STATUS_TAG, "[%s]-> [room C°: %.1f, operating: %s, compressor freq: %2d Hz]",
+    ESP_LOGI(LOG_STATUS_TAG, "[%s]-> [room C°: %.1f, operating: %s, compressor freq: %.1f Hz]",
         statusName,
         status.roomTemperature,
         status.operating ? "YES" : "NO ",
         status.compressorFrequency);
 #else
-    ESP_LOGI(LOG_STATUS_TAG, "[%-*s]-> [room C°: %.1f, operating: %-*s, compressor freq: %2d Hz]",
+    ESP_LOGI(LOG_STATUS_TAG, "[%-*s]-> [room C°: %.1f, operating: %-*s, compressor freq: %.1f Hz]",
         15, statusName,
         status.roomTemperature,
         3, status.operating ? "YES" : "NO ",
@@ -280,7 +280,7 @@ void CN105Climate::logDelegate() {
     } else {
         ESP_LOGI("testMutex", "Mutex est déjà verrouillé");
     }
-#endif    
+#endif
 }
 
 void CN105Climate::testCase1() {


### PR DESCRIPTION
This patch adds support for compressor frequency in 16-bit format with 1 decimal accuracy. My MSZ-RW25VG-SC1 reports the frequency in new format with the old byte set to zero:
```
[04:17:42][D][READ:170]: FC 62 01 30 10 06 00 00 00 01 01 DD 05 7C 00 00 42 00 00 00 00 B5 
[04:17:44][D][READ:170]: FC 62 01 30 10 06 00 00 00 01 01 F2 05 7C 00 00 42 00 00 00 00 A0 
[04:17:54][D][READ:170]: FC 62 01 30 10 06 00 00 00 01 01 F8 05 7D 00 00 42 00 00 00 00 99 
[04:18:05][D][READ:170]: FC 62 01 30 10 06 00 00 00 01 01 F5 05 7D 00 00 42 00 00 00 00 9C 
[09:12:11][D][READ:170]: FC 62 01 30 10 06 00 00 00 00 00 62 05 91 00 00 42 00 00 00 00 1D 
[09:12:13][D][READ:170]: FC 62 01 30 10 06 00 00 00 00 00 35 05 91 00 00 42 00 00 00 00 4A 
[09:12:25][D][READ:170]: FC 62 01 30 10 06 00 00 00 00 00 08 05 91 00 00 42 00 00 00 00 77 
``` 
