### PR TITLE
Add support for outside air temperature sensor

### DIFF
--- a/components/cn105/Globals.h
+++ b/components/cn105/Globals.h
@@ -244,12 +244,14 @@ struct heatpumpTimers {
 
 struct heatpumpStatus {
     float roomTemperature;
+    float outsideAirTemperature;
     bool operating; // if true, the heatpump is operating to reach the desired temperature
     heatpumpTimers timers;
     int compressorFrequency;
 
     bool operator==(const heatpumpStatus& other) const {
         return roomTemperature == other.roomTemperature &&
+	    outsideAirTemperature == other.outsideAirTemperature &&
             operating == other.operating &&
             //timers == other.timers &&  // Assurez-vous que l'opérateur == est également défini pour heatpumpTimers
             compressorFrequency == other.compressorFrequency;

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -35,6 +35,7 @@ CONF_SUPPORTS = "supports"
 CONF_HORIZONTAL_SWING_SELECT = "horizontal_vane_select"
 CONF_VERTICAL_SWING_SELECT = "vertical_vane_select"
 CONF_COMPRESSOR_FREQUENCY_SENSOR = "compressor_frequency_sensor"
+CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR = "outside_air_temperature_sensor"
 CONF_ISEE_SENSOR = "isee_sensor"
 CONF_STAGE_SENSOR = "stage_sensor"
 CONF_SUB_MODE_SENSOR = "sub_mode_sensor"
@@ -57,6 +58,10 @@ VaneOrientationSelect = cg.global_ns.class_(
 
 CompressorFrequencySensor = cg.global_ns.class_(
     "CompressorFrequencySensor", sensor.Sensor, cg.Component
+)
+
+OutsideAirTemperatureSensor = cg.global_ns.class_(
+    "OutsideAirTemperatureSensor", sensor.Sensor, cg.Component
 )
 
 ISeeSensor = cg.global_ns.class_("ISeeSensor", binary_sensor.BinarySensor, cg.Component)
@@ -87,8 +92,12 @@ SELECT_SCHEMA = select.SELECT_SCHEMA.extend(
     {cv.GenerateID(CONF_ID): cv.declare_id(VaneOrientationSelect)}
 )
 
-SENSOR_SCHEMA = sensor.SENSOR_SCHEMA.extend(
+COMPRESSOR_FREQUENCY_SENSOR_SCHEMA = sensor.SENSOR_SCHEMA.extend(
     {cv.GenerateID(CONF_ID): cv.declare_id(CompressorFrequencySensor)}
+)
+
+OUTSIDE_AIR_TEMPERATURE_SENSOR_SCHEMA = sensor.SENSOR_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(OutsideAirTemperatureSensor)}
 )
 
 ISEE_SENSOR_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend(
@@ -132,7 +141,8 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_UPDATE_INTERVAL, default="2s"): cv.All(cv.update_interval),
         cv.Optional(CONF_HORIZONTAL_SWING_SELECT): SELECT_SCHEMA,
         cv.Optional(CONF_VERTICAL_SWING_SELECT): SELECT_SCHEMA,
-        cv.Optional(CONF_COMPRESSOR_FREQUENCY_SENSOR): SENSOR_SCHEMA,
+        cv.Optional(CONF_COMPRESSOR_FREQUENCY_SENSOR): COMPRESSOR_FREQUENCY_SENSOR_SCHEMA,
+        cv.Optional(CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR): OUTSIDE_AIR_TEMPERATURE_SENSOR_SCHEMA,
         cv.Optional(CONF_ISEE_SENSOR): ISEE_SENSOR_SCHEMA,
         cv.Optional(CONF_STAGE_SENSOR): STAGE_SENSOR_SCHEMA,
         cv.Optional(CONF_SUB_MODE_SENSOR): SUB_MODE_SENSOR_SCHEMA,
@@ -208,6 +218,13 @@ def to_code(config):
         sensor_ = yield sensor.new_sensor(conf)
         yield cg.register_component(sensor_, conf)
         cg.add(var.set_compressor_frequency_sensor(sensor_))
+
+    if CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR in config:
+        conf = config[CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR]
+        conf["force_update"] = False
+        sensor_ = yield sensor.new_sensor(conf)
+        yield cg.register_component(sensor_, conf)
+        cg.add(var.set_outside_air_temperature_sensor(sensor_))
 
     if CONF_ISEE_SENSOR in config:
         conf = config[CONF_ISEE_SENSOR]

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -178,4 +178,3 @@ bool CN105Climate::isHeatpumpConnectionActive() {
 
     return  (lrTimeMs < MAX_DELAY_RESPONSE_FACTOR * this->update_interval_);
 }
-

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -4,6 +4,7 @@
 #include "van_orientation_select.h"
 #include "uptime_connection_sensor.h"
 #include "compressor_frequency_sensor.h"
+#include "outside_air_temperature_sensor.h"
 #include "auto_sub_mode_sensor.h"
 #include "isee_sensor.h"
 #include "stage_sensor.h"
@@ -33,6 +34,7 @@ public:
     void set_vertical_vane_select(VaneOrientationSelect* vertical_vane_select);
     void set_horizontal_vane_select(VaneOrientationSelect* horizontal_vane_select);
     void set_compressor_frequency_sensor(esphome::sensor::Sensor* compressor_frequency_sensor);
+    void set_outside_air_temperature_sensor(esphome::sensor::Sensor* outside_air_temperature_sensor);
     void set_isee_sensor(esphome::binary_sensor::BinarySensor* iSee_sensor);
     void set_stage_sensor(esphome::text_sensor::TextSensor* Stage_sensor);
     void set_sub_mode_sensor(esphome::text_sensor::TextSensor* Sub_mode_sensor);
@@ -54,6 +56,8 @@ public:
         nullptr;  // Select to store manual position of horizontal swing
     sensor::Sensor* compressor_frequency_sensor_ =
         nullptr;  // Sensor to store compressor frequency
+    sensor::Sensor* outside_air_temperature_sensor_ =
+	nullptr;  // Outside air temperature
 
     // sensor to monitor heatpump connection time 
     uptime::HpUpTimeConnectionSensor* hp_uptime_connection_sensor_ = nullptr;
@@ -285,7 +289,7 @@ private:
     uint8_t* data;
 
     // initialise to all off, then it will update shortly after connect;
-    heatpumpStatus currentStatus{ 0, false, {TIMER_MODE_MAP[0], 0, 0, 0, 0}, 0 };
+    heatpumpStatus currentStatus{ 0, 0, false, {TIMER_MODE_MAP[0], 0, 0, 0, 0}, 0 };
     heatpumpFunctions functions;
 
     bool tempMode = false;

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -57,6 +57,11 @@ void CN105Climate::set_compressor_frequency_sensor(
     this->compressor_frequency_sensor_ = compressor_frequency_sensor;
 }
 
+void CN105Climate::set_outside_air_temperature_sensor(
+    sensor::Sensor* outside_air_temperature_sensor) {
+    this->outside_air_temperature_sensor_ = outside_air_temperature_sensor;
+}
+
 void CN105Climate::set_isee_sensor(esphome::binary_sensor::BinarySensor* iSee_sensor) {
     this->iSee_sensor_ = iSee_sensor;
 }

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -228,6 +228,18 @@ void CN105Climate::getRoomTemperatureFromResponsePacket() {
 
     //ESP_LOGD("Decoder", "[0x03 room temperature]");
     //this->last_received_packet_sensor->publish_state("0x62-> 0x03: Data -> Room temperature");        
+    //                 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+    // FC 62 01 30 10 03 00 00 0E 00 94 B0 B0 FE 42 00 01 0A 64 00 00 A9
+    //                         RT    OT RT SP ?? ?? ??    CT CT
+    // RT = room temperature (in old format and in new format)
+    // OT = outside air temperature
+    // SP = room setpoint temperature?
+    // CT = increasing counter (unknown function)
+
+    if (data[5] != 0x00)
+	receivedStatus.outsideAirTemperature = (float)(data[5] - 128) / 2;
+    else
+	receivedStatus.outsideAirTemperature = -1;
 
     if (data[6] != 0x00) {
         int temp = data[6];
@@ -236,7 +248,9 @@ void CN105Climate::getRoomTemperatureFromResponsePacket() {
     } else {
         receivedStatus.roomTemperature = lookupByteMapValue(ROOM_TEMP_MAP, ROOM_TEMP, 32, data[3]);
     }
+
     ESP_LOGD("Decoder", "[Room °C: %f]", receivedStatus.roomTemperature);
+    ESP_LOGD("Decoder", "[OAT  °C: %f]", receivedStatus.outsideAirTemperature);
 
     // no change with this packet to currentStatus for operating and compressorFrequency
     receivedStatus.operating = currentStatus.operating;
@@ -257,6 +271,7 @@ void CN105Climate::getOperatingAndCompressorFreqFromResponsePacket() {
 
     // no change with this packet to roomTemperature
     receivedStatus.roomTemperature = currentStatus.roomTemperature;
+    receivedStatus.outsideAirTemperature = currentStatus.outsideAirTemperature;
     this->statusChanged(receivedStatus);
 }
 
@@ -406,6 +421,7 @@ void CN105Climate::statusChanged(heatpumpStatus status) {
         this->currentStatus.operating = status.operating;
         this->currentStatus.compressorFrequency = status.compressorFrequency;
         this->currentStatus.roomTemperature = status.roomTemperature;
+        this->currentStatus.outsideAirTemperature = status.outsideAirTemperature;
         this->current_temperature = currentStatus.roomTemperature;
 
         this->updateAction();       // update action info on HA climate component        
@@ -413,6 +429,10 @@ void CN105Climate::statusChanged(heatpumpStatus status) {
 
         if (this->compressor_frequency_sensor_ != nullptr) {
             this->compressor_frequency_sensor_->publish_state(currentStatus.compressorFrequency);
+        }
+
+        if (this->outside_air_temperature_sensor_ != nullptr) {
+            this->outside_air_temperature_sensor_->publish_state(currentStatus.outsideAirTemperature);
         }
     } // else no change
 }
@@ -622,4 +642,3 @@ void CN105Climate::checkPowerAndModeSettings(heatpumpSettings& settings, bool up
         }
     }
 }
-

--- a/components/cn105/outside_air_temperature_sensor.h
+++ b/components/cn105/outside_air_temperature_sensor.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+
+
+namespace esphome {
+
+    class OutsideAirTemperatureSensor : public sensor::Sensor, public Component {
+    public:
+        OutsideAirTemperatureSensor() {
+            this->set_unit_of_measurement("°C");
+            this->set_accuracy_decimals(1);
+        }
+    };
+
+}


### PR DESCRIPTION
This patch adds a new outside air temperature sensor. Works for my MUZ-RW25VGHZ-SC1 / MSZ-RW25VG-SC1 unit. The sensor seems to have a resolution of 1C.

The sensor needs to be added into the yaml configuration also:
```
climate:
  - platform: cn105
    id: hp
    name: ${friendly_name}
    icon: mdi:heat-pump
    visual:
      min_temperature: 15
      max_temperature: 31
      temperature_step:
        target_temperature: 0.5
        current_temperature: 0.1
    compressor_frequency_sensor:
      name: ${name} Compressor Frequency
    outside_air_temperature_sensor:
      name: ${name} Outside air temperature
    vertical_vane_select:
      name: ${name} Vertical Vane
    horizontal_vane_select:
      name: ${name} Horizontal Vane
    isee_sensor:
      name: ${name} ISEE Sensor
    auto_sub_mode_sensor:
      name: auto-submode sensor
    sub_mode_sensor:
      name: submode sensor
    stage_sensor:
      name: stage sensor
    remote_temperature_timeout: 30min
    debounce_delay : 400ms
    update_interval: 1s
``` 
