### PR TITLE
New sensors and various fixes

### DIFF
--- a/components/cn105/Globals.h
+++ b/components/cn105/Globals.h
@@ -248,13 +248,19 @@ struct heatpumpStatus {
     bool operating; // if true, the heatpump is operating to reach the desired temperature
     heatpumpTimers timers;
     float compressorFrequency;
+    float inputPower;
+    float kWh;
+    float runtimeHours;
 
     bool operator==(const heatpumpStatus& other) const {
         return roomTemperature == other.roomTemperature &&
 	    outsideAirTemperature == other.outsideAirTemperature &&
             operating == other.operating &&
             //timers == other.timers &&  // Assurez-vous que l'opérateur == est également défini pour heatpumpTimers
-            compressorFrequency == other.compressorFrequency;
+            compressorFrequency == other.compressorFrequency &&
+            inputPower == other.inputPower &&
+            kWh == other.kWh &&
+            runtimeHours == other.runtimeHours;
     }
 
     bool operator!=(const heatpumpStatus& other) const {

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -35,6 +35,9 @@ CONF_SUPPORTS = "supports"
 CONF_HORIZONTAL_SWING_SELECT = "horizontal_vane_select"
 CONF_VERTICAL_SWING_SELECT = "vertical_vane_select"
 CONF_COMPRESSOR_FREQUENCY_SENSOR = "compressor_frequency_sensor"
+CONF_INPUT_POWER_SENSOR = "input_power_sensor"
+CONF_KWH_SENSOR = "kwh_sensor"
+CONF_RUNTIME_HOURS_SENSOR = "runtime_hours_sensor"
 CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR = "outside_air_temperature_sensor"
 CONF_ISEE_SENSOR = "isee_sensor"
 CONF_STAGE_SENSOR = "stage_sensor"
@@ -58,6 +61,18 @@ VaneOrientationSelect = cg.global_ns.class_(
 
 CompressorFrequencySensor = cg.global_ns.class_(
     "CompressorFrequencySensor", sensor.Sensor, cg.Component
+)
+
+InputPowerSensor = cg.global_ns.class_(
+    "InputPowerSensor", sensor.Sensor, cg.Component
+)
+
+kWhSensor = cg.global_ns.class_(
+    "kWhSensor", sensor.Sensor, cg.Component
+)
+
+RuntimeHoursSensor = cg.global_ns.class_(
+    "RuntimeHoursSensor", sensor.Sensor, cg.Component
 )
 
 OutsideAirTemperatureSensor = cg.global_ns.class_(
@@ -94,6 +109,18 @@ SELECT_SCHEMA = select.SELECT_SCHEMA.extend(
 
 COMPRESSOR_FREQUENCY_SENSOR_SCHEMA = sensor.SENSOR_SCHEMA.extend(
     {cv.GenerateID(CONF_ID): cv.declare_id(CompressorFrequencySensor)}
+)
+
+INPUT_POWER_SENSOR_SCHEMA = sensor.SENSOR_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(InputPowerSensor)}
+)
+
+KWH_SENSOR_SCHEMA = sensor.SENSOR_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(kWhSensor)}
+)
+
+RUNTIME_HOURS_SENSOR_SCHEMA = sensor.SENSOR_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(RuntimeHoursSensor)}
 )
 
 OUTSIDE_AIR_TEMPERATURE_SENSOR_SCHEMA = sensor.SENSOR_SCHEMA.extend(
@@ -142,6 +169,9 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_HORIZONTAL_SWING_SELECT): SELECT_SCHEMA,
         cv.Optional(CONF_VERTICAL_SWING_SELECT): SELECT_SCHEMA,
         cv.Optional(CONF_COMPRESSOR_FREQUENCY_SENSOR): COMPRESSOR_FREQUENCY_SENSOR_SCHEMA,
+        cv.Optional(CONF_INPUT_POWER_SENSOR): INPUT_POWER_SENSOR_SCHEMA,
+        cv.Optional(CONF_KWH_SENSOR): KWH_SENSOR_SCHEMA,
+        cv.Optional(CONF_RUNTIME_HOURS_SENSOR): RUNTIME_HOURS_SENSOR_SCHEMA,
         cv.Optional(CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR): OUTSIDE_AIR_TEMPERATURE_SENSOR_SCHEMA,
         cv.Optional(CONF_ISEE_SENSOR): ISEE_SENSOR_SCHEMA,
         cv.Optional(CONF_STAGE_SENSOR): STAGE_SENSOR_SCHEMA,
@@ -218,6 +248,27 @@ def to_code(config):
         sensor_ = yield sensor.new_sensor(conf)
         yield cg.register_component(sensor_, conf)
         cg.add(var.set_compressor_frequency_sensor(sensor_))
+
+    if CONF_INPUT_POWER_SENSOR in config:
+        conf = config[CONF_INPUT_POWER_SENSOR]
+        conf["force_update"] = False
+        sensor_ = yield sensor.new_sensor(conf)
+        yield cg.register_component(sensor_, conf)
+        cg.add(var.set_input_power_sensor(sensor_))
+
+    if CONF_KWH_SENSOR in config:
+        conf = config[CONF_KWH_SENSOR]
+        conf["force_update"] = False
+        sensor_ = yield sensor.new_sensor(conf)
+        yield cg.register_component(sensor_, conf)
+        cg.add(var.set_kwh_sensor(sensor_))
+
+    if CONF_RUNTIME_HOURS_SENSOR in config:
+        conf = config[CONF_RUNTIME_HOURS_SENSOR]
+        conf["force_update"] = False
+        sensor_ = yield sensor.new_sensor(conf)
+        yield cg.register_component(sensor_, conf)
+        cg.add(var.set_runtime_hours_sensor(sensor_))
 
     if CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR in config:
         conf = config[CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR]

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -26,13 +26,19 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
     this->infoMode = 0;
     this->lastConnectRqTimeMs = 0;
     this->currentStatus.operating = false;
-    this->currentStatus.compressorFrequency = -1;
+    this->currentStatus.compressorFrequency = NAN;
+    this->currentStatus.inputPower = NAN;
+    this->currentStatus.kWh = NAN;
+    this->currentStatus.runtimeHours = NAN;
     this->tx_pin_ = -1;
     this->rx_pin_ = -1;
 
     this->horizontal_vane_select_ = nullptr;
     this->vertical_vane_select_ = nullptr;
     this->compressor_frequency_sensor_ = nullptr;
+    this->input_power_sensor_ = nullptr;
+    this->kwh_sensor_ = nullptr;
+    this->runtime_hours_sensor_ = nullptr;
 
     this->powerRequestWithoutResponses = 0;     // power request is not supported by all heatpump #112
 
@@ -86,6 +92,15 @@ void CN105Climate::set_debounce_delay(uint32_t delay) {
 
 float CN105Climate::get_compressor_frequency() {
     return currentStatus.compressorFrequency;
+}
+float CN105Climate::get_input_power() {
+    return currentStatus.inputPower;
+}
+float CN105Climate::get_kwh() {
+    return currentStatus.kWh;
+}
+float CN105Climate::get_runtime_hours() {
+    return currentStatus.runtimeHours;
 }
 bool CN105Climate::is_operating() {
     return currentStatus.operating;

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -4,6 +4,9 @@
 #include "van_orientation_select.h"
 #include "uptime_connection_sensor.h"
 #include "compressor_frequency_sensor.h"
+#include "input_power_sensor.h"
+#include "kwh_sensor.h"
+#include "runtime_hours_sensor.h"
 #include "outside_air_temperature_sensor.h"
 #include "auto_sub_mode_sensor.h"
 #include "isee_sensor.h"
@@ -34,6 +37,9 @@ public:
     void set_vertical_vane_select(VaneOrientationSelect* vertical_vane_select);
     void set_horizontal_vane_select(VaneOrientationSelect* horizontal_vane_select);
     void set_compressor_frequency_sensor(esphome::sensor::Sensor* compressor_frequency_sensor);
+    void set_input_power_sensor(esphome::sensor::Sensor* input_power_sensor);
+    void set_kwh_sensor(esphome::sensor::Sensor* kwh_sensor);
+    void set_runtime_hours_sensor(esphome::sensor::Sensor* runtime_hours_sensor);
     void set_outside_air_temperature_sensor(esphome::sensor::Sensor* outside_air_temperature_sensor);
     void set_isee_sensor(esphome::binary_sensor::BinarySensor* iSee_sensor);
     void set_stage_sensor(esphome::text_sensor::TextSensor* Stage_sensor);
@@ -56,6 +62,12 @@ public:
         nullptr;  // Select to store manual position of horizontal swing
     sensor::Sensor* compressor_frequency_sensor_ =
         nullptr;  // Sensor to store compressor frequency
+    sensor::Sensor* input_power_sensor_ =
+        nullptr;  // Sensor to store compressor frequency
+    sensor::Sensor* kwh_sensor_ =
+        nullptr;  // Sensor to store compressor frequency
+    sensor::Sensor* runtime_hours_sensor_ =
+        nullptr;  // Sensor to store compressor frequency
     sensor::Sensor* outside_air_temperature_sensor_ =
 	nullptr;  // Outside air temperature
 
@@ -63,6 +75,9 @@ public:
     uptime::HpUpTimeConnectionSensor* hp_uptime_connection_sensor_ = nullptr;
 
     float get_compressor_frequency();
+    float get_input_power();
+    float get_kwh();
+    float get_runtime_hours();
     bool is_operating();
 
     // checks if the field has changed
@@ -289,7 +304,7 @@ private:
     uint8_t* data;
 
     // initialise to all off, then it will update shortly after connect;
-    heatpumpStatus currentStatus{ 0, 0, false, {TIMER_MODE_MAP[0], 0, 0, 0, 0}, 0 };
+    heatpumpStatus currentStatus{ 0, 0, false, {TIMER_MODE_MAP[0], 0, 0, 0, 0}, 0, 0, 0, 0 };
     heatpumpFunctions functions;
 
     bool tempMode = false;

--- a/components/cn105/compressor_frequency_sensor.h
+++ b/components/cn105/compressor_frequency_sensor.h
@@ -10,6 +10,8 @@ namespace esphome {
     public:
         CompressorFrequencySensor() {
             this->set_unit_of_measurement("Hz");
+            this->set_device_class("frequency");
+            this->set_state_class(sensor::StateClass::STATE_CLASS_MEASUREMENT);
             this->set_accuracy_decimals(1);
         }
     };

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -57,6 +57,21 @@ void CN105Climate::set_compressor_frequency_sensor(
     this->compressor_frequency_sensor_ = compressor_frequency_sensor;
 }
 
+void CN105Climate::set_input_power_sensor(
+    sensor::Sensor* input_power_sensor) {
+    this->input_power_sensor_ = input_power_sensor;
+}
+
+void CN105Climate::set_kwh_sensor(
+    sensor::Sensor* kwh_sensor) {
+    this->kwh_sensor_ = kwh_sensor;
+}
+
+void CN105Climate::set_runtime_hours_sensor(
+    sensor::Sensor* runtime_hours_sensor) {
+    this->runtime_hours_sensor_ = runtime_hours_sensor;
+}
+
 void CN105Climate::set_outside_air_temperature_sensor(
     sensor::Sensor* outside_air_temperature_sensor) {
     this->outside_air_temperature_sensor_ = outside_air_temperature_sensor;

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -290,6 +290,8 @@ void CN105Climate::getOperatingAndCompressorFreqFromResponsePacket() {
 
 void CN105Climate::terminateCycle() {
     if (this->shouldSendExternalTemperature_) {
+	// We will receive ACK packet for this.
+	// Sending WantedSettings must be delayed in this case (lastSend timestamp updated).
         this->sendRemoteTemperature();
     }
 

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -600,7 +600,8 @@ void CN105Climate::checkFanSettings(heatpumpSettings& settings, bool updateCurre
         if (updateCurrentSettings) {
             currentSettings.fan = settings.fan;
         }
-        if (strcmp(currentSettings.fan, "QUIET") == 0) {
+
+        if (strcmp(settings.fan, "QUIET") == 0) {
             this->fan_mode = climate::CLIMATE_FAN_QUIET;
         } else if (strcmp(settings.fan, "1") == 0) {
             this->fan_mode = climate::CLIMATE_FAN_LOW;

--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -88,6 +88,9 @@ void CN105Climate::writePacket(uint8_t* packet, int length, bool checkIsActive) 
             this->get_hw_serial_()->write_byte((uint8_t)packet[i]);
         }
 
+	// Prevent sending wantedSettings too soon after writing for example the remote temperature update packet
+        this->lastSend = CUSTOM_MILLIS;
+
     } else {
         ESP_LOGW(TAG, "could not write as asked, because UART is not connected");
         this->reconnectUART();

--- a/components/cn105/input_power_sensor.h
+++ b/components/cn105/input_power_sensor.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+
+
+namespace esphome {
+
+    class InputPowerSensor : public sensor::Sensor, public Component {
+    public:
+        InputPowerSensor() {
+            this->set_unit_of_measurement("W");
+            this->set_device_class("power");
+            this->set_state_class(sensor::StateClass::STATE_CLASS_MEASUREMENT);
+            this->set_accuracy_decimals(0);
+        }
+    };
+
+}

--- a/components/cn105/kwh_sensor.h
+++ b/components/cn105/kwh_sensor.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+
+
+namespace esphome {
+
+    class kWhSensor : public sensor::Sensor, public Component {
+    public:
+        kWhSensor() {
+            this->set_unit_of_measurement("kWh");
+            this->set_device_class("energy");
+            this->set_state_class(sensor::StateClass::STATE_CLASS_TOTAL_INCREASING);
+            this->set_accuracy_decimals(1);
+        }
+    };
+
+}

--- a/components/cn105/outside_air_temperature_sensor.h
+++ b/components/cn105/outside_air_temperature_sensor.h
@@ -10,6 +10,8 @@ namespace esphome {
     public:
         OutsideAirTemperatureSensor() {
             this->set_unit_of_measurement("°C");
+            this->set_device_class("temperature");
+            this->set_state_class(sensor::StateClass::STATE_CLASS_MEASUREMENT);
             this->set_accuracy_decimals(1);
         }
     };

--- a/components/cn105/runtime_hours_sensor.h
+++ b/components/cn105/runtime_hours_sensor.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+
+
+namespace esphome {
+
+    class RuntimeHoursSensor : public sensor::Sensor, public Component {
+    public:
+        RuntimeHoursSensor() {
+            this->set_unit_of_measurement("h");
+            this->set_device_class("duration");
+            this->set_state_class(sensor::StateClass::STATE_CLASS_TOTAL_INCREASING);
+            this->set_accuracy_decimals(2);
+        }
+    };
+
+}


### PR DESCRIPTION
This PR includes the following changes:

- Fix WantedSettings getting sometimes ignored (for example a fan speed change can get ignored because it is sent too soon after a remote temperature update packet).
- Fix fan setting comparison (switching to QUIET fan setting was not working correctly).
- Revert the compressor frequency pr #163 because the new data seems to be the current input power and not the actual compressor frequency. It seems like the compressor frequency information is not available on all units.
- Add a new current input power in Watts sensor.
- Add a new total consumed energy in kWh sensor. Needs further updating later after figured out what happens when the 16-bit counter flips over (it could extend to new bytes).
- Add a new total indoor unit runtime in hours. Needs further updating later after figured out what happens when the 24-bit counter flips over (it could extend to new bytes).

Please test and comment before merging.