### PR TITLE
Widevane

### DIFF
--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -205,7 +205,7 @@ void CN105Climate::getSettingsFromResponsePacket() {
     if (this->wideVaneAdj) {
         receivedSettings.wideVane = lookupByteMapValue(WIDEVANE_MAP, WIDEVANE, 7, data[10] & 0x0F, "wideVane reading", WIDEVANE_MAP[2]);
     }
-
+    ESP_LOGD("Decoder", "[wideVane: %s (adj:%d)]", receivedSettings.wideVane, this->wideVaneAdj);
     /*if ((data[10] != 0) && (this->traits_.supports_swing_mode(climate::CLIMATE_SWING_HORIZONTAL))) {    // wideVane is not always supported
         receivedSettings.wideVane = lookupByteMapValue(WIDEVANE_MAP, WIDEVANE, 7, data[10] & 0x0F, "wideVane reading");
         wideVaneAdj = (data[10] & 0xF0) == 0x80 ? true : false;

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -202,9 +202,7 @@ void CN105Climate::getSettingsFromResponsePacket() {
 
 
     this->wideVaneAdj = (data[10] & 0xF0) == 0x80 ? true : false;
-    if (this->wideVaneAdj) {
-        receivedSettings.wideVane = lookupByteMapValue(WIDEVANE_MAP, WIDEVANE, 7, data[10] & 0x0F, "wideVane reading", WIDEVANE_MAP[2]);
-    }
+    receivedSettings.wideVane = lookupByteMapValue(WIDEVANE_MAP, WIDEVANE, 7, data[10] & 0x0F, "wideVane reading");
     ESP_LOGD("Decoder", "[wideVane: %s (adj:%d)]", receivedSettings.wideVane, this->wideVaneAdj);
     /*if ((data[10] != 0) && (this->traits_.supports_swing_mode(climate::CLIMATE_SWING_HORIZONTAL))) {    // wideVane is not always supported
         receivedSettings.wideVane = lookupByteMapValue(WIDEVANE_MAP, WIDEVANE, 7, data[10] & 0x0F, "wideVane reading");


### PR DESCRIPTION
I updated the code to be similar as the SwiCago Heatpump reading of the wide vane. This works for my heat-pump. 

It seems that this setting has been subject to multiple attempts, so I don’t know whether this change will break functionality for some pumps. 

Solves https://github.com/echavet/MitsubishiCN105ESPHome/issues/152 for me