### PR TITLE
Indicate that external temperature sensor does not work with with MXZ-3C24NA2

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ Compatible units (as reported by users):
 | MSZ-AP71VGD     | MUZ-AP71VG       | Works but reports -63.5C when idle      |
 | MSZ-AY35VGKP    | MUZ-AY35VG       | Works                                   |
 | MSZ-GLxxNA      | MXZ-SM42NAMHZ    | Works                                   |
+|                 | MXZ-3C24NA2      | Not working                             |
 | MSZ-RW25VG-SC1  | MUZ-RW25VGHZ-SC1 | Works                                   |
 |                 | MUZ-FD25NA       | Not working                             |
 | MSZ-LN35        | MUZ-LN35         | Not working                             |


### PR DESCRIPTION
Indicate that external temperature sensor does not work with with MXZ-3C24NA2