### PR TITLE
Publish updates only on changes

### DIFF
--- a/components/cn105/Globals.h
+++ b/components/cn105/Globals.h
@@ -253,8 +253,8 @@ struct heatpumpStatus {
     float runtimeHours;
 
     bool operator==(const heatpumpStatus& other) const {
-        return roomTemperature == other.roomTemperature &&
-	    outsideAirTemperature == other.outsideAirTemperature &&
+        return (std::isnan(roomTemperature) ? std::isnan(other.roomTemperature) : roomTemperature == other.roomTemperature) &&
+            (std::isnan(outsideAirTemperature) ? std::isnan(other.outsideAirTemperature) : outsideAirTemperature == other.outsideAirTemperature) &&
             operating == other.operating &&
             //timers == other.timers &&  // Assurez-vous que l'opérateur == est également défini pour heatpumpTimers
             compressorFrequency == other.compressorFrequency &&

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -157,13 +157,16 @@ void CN105Climate::getPowerFromResponsePacket() {
     ESP_LOGD("Decoder", "[Auto Mode Sub Mode  : %s]", receivedSettings.auto_sub_mode);
 
     //this->heatpumpUpdate(receivedSettings);
-    if (this->Stage_sensor_ != nullptr) {
+    if (this->Stage_sensor_ != nullptr && (!this->currentSettings.stage || strcmp(receivedSettings.stage, this->currentSettings.stage) != 0)) {
+        this->currentSettings.stage = receivedSettings.stage;
         this->Stage_sensor_->publish_state(receivedSettings.stage);
     }
-    if (this->Sub_mode_sensor_ != nullptr) {
+    if (this->Sub_mode_sensor_ != nullptr && (!this->currentSettings.sub_mode || strcmp(receivedSettings.sub_mode, this->currentSettings.sub_mode) != 0)) {
+        this->currentSettings.sub_mode = receivedSettings.sub_mode;
         this->Sub_mode_sensor_->publish_state(receivedSettings.sub_mode);
     }
-    if (this->Auto_sub_mode_sensor_ != nullptr) {
+    if (this->Auto_sub_mode_sensor_ != nullptr && (!this->currentSettings.sub_mode || strcmp(receivedSettings.auto_sub_mode, this->currentSettings.auto_sub_mode) != 0)) {
+        this->currentSettings.auto_sub_mode = receivedSettings.auto_sub_mode;
         this->Auto_sub_mode_sensor_->publish_state(receivedSettings.auto_sub_mode);
     }
 }
@@ -517,8 +520,8 @@ void CN105Climate::heatpumpUpdate(heatpumpSettings& settings) {
 
     if (this->currentSettings != settings) {
         ESP_LOGD(LOG_SETTINGS_TAG, "Settings changed, updating HA states");
+        this->publishStateToHA(settings);
     }
-    this->publishStateToHA(settings);
 }
 
 void CN105Climate::checkVaneSettings(heatpumpSettings& settings, bool updateCurrentSettings) {

--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -212,7 +212,7 @@ void CN105Climate::createPacket(uint8_t* packet) {
 
 void CN105Climate::publishWantedSettingsStateToHA() {
 
-    if ((this->wantedSettings.mode != nullptr) || (this->wantedSettings.mode != nullptr)) {
+    if ((this->wantedSettings.mode != nullptr) || (this->wantedSettings.power != nullptr)) {
         checkPowerAndModeSettings(this->wantedSettings, false);
         this->updateAction();       // update action info on HA climate component
     }


### PR DESCRIPTION
There was already a check to only publish new status values when the status changed, but it had a bug: when comparing two `nan` values for `outsideAirTemperature`, the equality check would fail because `nan == nan` always fails in C++.

There was also already a check to only publish new setting values when the settings changed, but the line wasn't included in the otherwise empty if block (maybe by mistake).

Stage, sub mode, and auto sub mode statuses needed new checks, since it appears they were excluded from the settings by commenting out `// this->heatpumpUpdate(receivedSettings)` and not including them in the `heatpumpSettings` equality checks. Maybe this was a work in progress, or excluded later.

Closes #206 