### PR TITLE
Fix typo with auto_sub_mode

### DIFF
--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -165,7 +165,7 @@ void CN105Climate::getPowerFromResponsePacket() {
         this->currentSettings.sub_mode = receivedSettings.sub_mode;
         this->Sub_mode_sensor_->publish_state(receivedSettings.sub_mode);
     }
-    if (this->Auto_sub_mode_sensor_ != nullptr && (!this->currentSettings.sub_mode || strcmp(receivedSettings.auto_sub_mode, this->currentSettings.auto_sub_mode) != 0)) {
+    if (this->Auto_sub_mode_sensor_ != nullptr && (!this->currentSettings.auto_sub_mode || strcmp(receivedSettings.auto_sub_mode, this->currentSettings.auto_sub_mode) != 0)) {
         this->currentSettings.auto_sub_mode = receivedSettings.auto_sub_mode;
         this->Auto_sub_mode_sensor_->publish_state(receivedSettings.auto_sub_mode);
     }


### PR DESCRIPTION
Was causing crash on units that exposed `auto_sub_mode`.