### PR TITLE
Support for viewing and setting installer functions

### DIFF
--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -10,9 +10,11 @@ from esphome.components import (
     uart,
     select,
     sensor,
+    button,
     binary_sensor,
     text_sensor,
     uptime,
+    number,
 )
 
 from esphome.components.logger import HARDWARE_UART_TO_SERIAL
@@ -38,9 +40,11 @@ AUTO_LOAD = [
     "sensor",
     "select",
     "binary_sensor",
+    "button",
     "text_sensor",
     "uart",
     "uptime",
+    "number",
 ]
 
 DEPENDENCIES = ["uptime"]
@@ -55,6 +59,11 @@ CONF_KWH_SENSOR = "kwh_sensor"
 CONF_RUNTIME_HOURS_SENSOR = "runtime_hours_sensor"
 CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR = "outside_air_temperature_sensor"
 CONF_ISEE_SENSOR = "isee_sensor"
+CONF_FUNCTIONS_SENSOR = "functions_sensor"
+CONF_FUNCTIONS_BUTTON = "functions_get_button"
+CONF_FUNCTIONS_SET_BUTTON = "functions_set_button"
+CONF_FUNCTIONS_SET_CODE = "functions_set_code"
+CONF_FUNCTIONS_SET_VALUE = "functions_set_value"
 CONF_STAGE_SENSOR = "stage_sensor"
 CONF_SUB_MODE_SENSOR = "sub_mode_sensor"
 CONF_AUTO_SUB_MODE_SENSOR = "auto_sub_mode_sensor"
@@ -92,6 +101,9 @@ OutsideAirTemperatureSensor = cg.global_ns.class_(
 
 ISeeSensor = cg.global_ns.class_("ISeeSensor", binary_sensor.BinarySensor, cg.Component)
 StageSensor = cg.global_ns.class_("StageSensor", text_sensor.TextSensor, cg.Component)
+FunctionsSensor = cg.global_ns.class_("FunctionsSensor", text_sensor.TextSensor, cg.Component)
+FunctionsButton = cg.global_ns.class_("FunctionsButton", button.Button, cg.Component)
+FunctionsNumber = cg.global_ns.class_("FunctionsNumber", number.Number, cg.Component)
 SubModSensor = cg.global_ns.class_("SubModSensor", text_sensor.TextSensor, cg.Component)
 AutoSubModSensor = cg.global_ns.class_(
     "AutoSubModSensor", text_sensor.TextSensor, cg.Component
@@ -143,6 +155,18 @@ ISEE_SENSOR_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend(
     {cv.GenerateID(CONF_ID): cv.declare_id(ISeeSensor)}
 )
 
+FUNCTIONS_SENSOR_SCHEMA = text_sensor.TEXT_SENSOR_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(FunctionsSensor)}
+)
+
+FUNCTIONS_BUTTON_SCHEMA = button.BUTTON_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(FunctionsButton)}
+)
+
+FUNCTIONS_NUMBER_SCHEMA = number.NUMBER_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(FunctionsNumber)}
+)
+
 STAGE_SENSOR_SCHEMA = text_sensor.TEXT_SENSOR_SCHEMA.extend(
     {cv.GenerateID(CONF_ID): cv.declare_id(StageSensor)}
 )
@@ -190,6 +214,11 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
             CONF_OUTSIDE_AIR_TEMPERATURE_SENSOR
         ): OUTSIDE_AIR_TEMPERATURE_SENSOR_SCHEMA,
         cv.Optional(CONF_ISEE_SENSOR): ISEE_SENSOR_SCHEMA,
+        cv.Optional(CONF_FUNCTIONS_SENSOR): FUNCTIONS_SENSOR_SCHEMA,
+        cv.Optional(CONF_FUNCTIONS_BUTTON): FUNCTIONS_BUTTON_SCHEMA,
+        cv.Optional(CONF_FUNCTIONS_SET_BUTTON): FUNCTIONS_BUTTON_SCHEMA,
+        cv.Optional(CONF_FUNCTIONS_SET_CODE): FUNCTIONS_NUMBER_SCHEMA,
+        cv.Optional(CONF_FUNCTIONS_SET_VALUE): FUNCTIONS_NUMBER_SCHEMA,
         cv.Optional(CONF_STAGE_SENSOR): STAGE_SENSOR_SCHEMA,
         cv.Optional(CONF_SUB_MODE_SENSOR): SUB_MODE_SENSOR_SCHEMA,
         cv.Optional(CONF_AUTO_SUB_MODE_SENSOR): AUTO_SUB_MODE_SENSOR_SCHEMA,
@@ -298,6 +327,36 @@ def to_code(config):
         bsensor_ = yield binary_sensor.new_binary_sensor(conf)
         yield cg.register_component(bsensor_, conf)
         cg.add(var.set_isee_sensor(bsensor_))
+
+    if CONF_FUNCTIONS_SENSOR in config:
+        conf = config[CONF_FUNCTIONS_SENSOR]
+        tsensor_ = yield text_sensor.new_text_sensor(conf)
+        yield cg.register_component(tsensor_, conf)
+        cg.add(var.set_functions_sensor(tsensor_))
+
+    if CONF_FUNCTIONS_BUTTON in config:
+        conf = config[CONF_FUNCTIONS_BUTTON]
+        button_ = yield button.new_button(conf)
+        yield cg.register_component(button_, conf)
+        cg.add(var.set_functions_get_button(button_))
+
+    if CONF_FUNCTIONS_SET_BUTTON in config:
+        conf = config[CONF_FUNCTIONS_SET_BUTTON]
+        button_ = yield button.new_button(conf)
+        yield cg.register_component(button_, conf)
+        cg.add(var.set_functions_set_button(button_))
+
+    if CONF_FUNCTIONS_SET_CODE in config:
+        conf = config[CONF_FUNCTIONS_SET_CODE]
+        number_ = yield number.new_number(conf, min_value=100, max_value=128, step=1)
+        yield cg.register_component(number_, conf)
+        cg.add(var.set_functions_set_code(number_))
+
+    if CONF_FUNCTIONS_SET_VALUE in config:
+        conf = config[CONF_FUNCTIONS_SET_VALUE]
+        number_ = yield number.new_number(conf, min_value=0, max_value=2, step=1)
+        yield cg.register_component(number_, conf)
+        cg.add(var.set_functions_set_value(number_))
 
     if CONF_STAGE_SENSOR in config:
         conf = config[CONF_STAGE_SENSOR]

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -11,8 +11,12 @@
 #include "auto_sub_mode_sensor.h"
 #include "isee_sensor.h"
 #include "stage_sensor.h"
+#include "functions_sensor.h"
+#include "functions_number.h"
+#include "functions_button.h"
 #include "sub_mode_sensor.h"
 #include <esphome/components/sensor/sensor.h>
+#include <esphome/components/button/button.h>
 #include <esphome/components/binary_sensor/binary_sensor.h>
 #include "cycle_management.h"
 
@@ -42,6 +46,13 @@ public:
     void set_outside_air_temperature_sensor(esphome::sensor::Sensor* outside_air_temperature_sensor);
     void set_isee_sensor(esphome::binary_sensor::BinarySensor* iSee_sensor);
     void set_stage_sensor(esphome::text_sensor::TextSensor* Stage_sensor);
+
+    void set_functions_sensor(esphome::text_sensor::TextSensor* Functions_sensor);
+    void set_functions_get_button(FunctionsButton* Button);
+    void set_functions_set_button(FunctionsButton* Button);
+    void set_functions_set_code(FunctionsNumber* Number);
+    void set_functions_set_value(FunctionsNumber* Number);
+
     void set_sub_mode_sensor(esphome::text_sensor::TextSensor* Sub_mode_sensor);
     void set_auto_sub_mode_sensor(esphome::text_sensor::TextSensor* Auto_sub_mode_sensor);
     void set_hp_uptime_connection_sensor(uptime::HpUpTimeConnectionSensor* hp_up_connection_sensor);
@@ -49,8 +60,17 @@ public:
     //sensor::Sensor* compressor_frequency_sensor;
     binary_sensor::BinarySensor* iSee_sensor_ = nullptr;
     text_sensor::TextSensor* Stage_sensor_ = nullptr;
+    text_sensor::TextSensor* Functions_sensor_ = nullptr;
+    FunctionsButton* Functions_get_button_ = nullptr;
+    FunctionsButton* Functions_set_button_ = nullptr;
+    FunctionsNumber* Functions_set_code_ = nullptr;
+    FunctionsNumber* Functions_set_value_ = nullptr;
     text_sensor::TextSensor* Sub_mode_sensor_ = nullptr;
     text_sensor::TextSensor* Auto_sub_mode_sensor_ = nullptr;
+
+    // The value of the code and value for the functions set.
+    int functions_code_;
+    int functions_value_;
 
     //select::Select* van_orientation;
 
@@ -152,7 +172,9 @@ public:
     //bool can_proceed() override;
 
 
-    heatpumpFunctions getFunctions();
+    void getFunctions();
+    void getFunctionsPart2();
+    void functionsArrived();
     bool setFunctions(heatpumpFunctions const& functions);
 
     // helpers

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -85,6 +85,55 @@ void CN105Climate::set_stage_sensor(esphome::text_sensor::TextSensor* Stage_sens
     this->Stage_sensor_ = Stage_sensor;
 }
 
+void CN105Climate::set_functions_sensor(esphome::text_sensor::TextSensor* Functions_sensor) {
+    this->Functions_sensor_ = Functions_sensor;
+}
+
+void CN105Climate::set_functions_get_button(FunctionsButton* Button) {
+    this->Functions_get_button_ = Button;
+    this->Functions_get_button_->setCallbackFunction([this]() {
+        ESP_LOGI(LOG_CYCLE_TAG, "Retrieving functions");
+        // Get the settings from the heat pump
+        this->getFunctions();
+        // The response is handled in heatpumpFunctions.cpp
+    });
+}
+
+void CN105Climate::set_functions_set_button(FunctionsButton* Button) {
+    this->Functions_set_button_ = Button;
+    this->Functions_set_button_->setCallbackFunction([this]() {
+
+        if (!functions.isValid()) {
+            this->Functions_sensor_->publish_state("Please get the functions first.");
+            return;
+        }
+
+        ESP_LOGI(LOG_CYCLE_TAG, "Setting code %i to value %i", this->functions_code_, this->functions_value_);
+        functions.setValue(this->functions_code_, this->functions_value_);
+
+        // Now send the codes.
+        this->setFunctions(functions);
+
+    });
+}
+
+void CN105Climate::set_functions_set_code(FunctionsNumber* Number) {
+    this->Functions_set_code_ = Number;
+    this->Functions_set_code_->setCallbackFunction([this](float x) {
+        // store the code
+        this->functions_code_ = (int)x;
+    });
+
+}
+void CN105Climate::set_functions_set_value(FunctionsNumber* Number) {
+    this->Functions_set_value_ = Number;
+    this->Functions_set_value_->setCallbackFunction([this](float x) {
+        // store the value
+        this->functions_value_ = (int)x;
+    });
+}
+
+
 void CN105Climate::set_sub_mode_sensor(esphome::text_sensor::TextSensor* Sub_mode_sensor) {
     this->Sub_mode_sensor_ = Sub_mode_sensor;
 }

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -104,7 +104,9 @@ void CN105Climate::set_functions_set_button(FunctionsButton* Button) {
     this->Functions_set_button_->setCallbackFunction([this]() {
 
         if (!functions.isValid()) {
-            this->Functions_sensor_->publish_state("Please get the functions first.");
+            if (this->Functions_sensor_ != nullptr) {
+                this->Functions_sensor_->publish_state("Please get the functions first.");
+            }
             return;
         }
 

--- a/components/cn105/functions_button.h
+++ b/components/cn105/functions_button.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+
+    class FunctionsButton : public button::Button, public Component {
+    public:
+        using CallbackFunction = std::function<void()>;
+
+        FunctionsButton() {}
+
+        // This callback function links the button press to the Climate component
+        void setCallbackFunction(CallbackFunction&& callback) {
+            this->callBackFunction = std::move(callback);
+        }
+
+    protected:
+        void press_action() override {
+            if (callBackFunction) {
+                callBackFunction(); // Trigger the callback function
+            }
+        }
+
+    private:
+        CallbackFunction callBackFunction;
+
+    };
+
+}

--- a/components/cn105/functions_number.h
+++ b/components/cn105/functions_number.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+
+    class FunctionsNumber : public number::Number, public Component {
+    public:
+        using CallbackFunction = std::function<void(float number)>;
+        FunctionsNumber() {}
+
+        // This callback function links the number changes back to the Climate component
+        void setCallbackFunction(CallbackFunction&& callback) {
+            this->callBackFunction = std::move(callback);
+        }
+
+    protected:
+        void control(float x) override { // called when the number changes
+            if (callBackFunction) {
+                callBackFunction(x); // Trigger the callback function
+            }
+        }
+
+    private:
+        CallbackFunction callBackFunction;
+    };
+}

--- a/components/cn105/functions_sensor.h
+++ b/components/cn105/functions_sensor.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+
+    class FunctionsSensor : public text_sensor::TextSensor, public Component {
+    public:
+        FunctionsSensor() {}
+    };
+
+}

--- a/components/cn105/heatpumpFunctions.cpp
+++ b/components/cn105/heatpumpFunctions.cpp
@@ -50,7 +50,9 @@ void CN105Climate::functionsArrived() {
     }
 
     // Publish the results of all the codes in the Functions sensor
-    this->Functions_sensor_->publish_state(states);
+    if (this->Functions_sensor_ != nullptr) {
+        this->Functions_sensor_->publish_state(states);
+    }
 
 }
 

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -381,19 +381,21 @@ void CN105Climate::getDataFromResponsePacket() {
         //this->getAutoModeStateFromResponsePacket();
         break;
 
-    case 0x20:
+    case 0x20: // fallthrough
     case 0x22: {
         ESP_LOGD("Decoder", "[Packet Functions 0x20 et 0x22]");
         //this->last_received_packet_sensor->publish_state("0x62-> 0x20/0x22: Data -> Packet functions");
         if (dataLength == 0x10) {
             if (data[0] == 0x20) {
                 functions.setData1(&data[1]);
+                ESP_LOGI(LOG_CYCLE_TAG, "Got functions packet 1, requesting part 2");
+                this->getFunctionsPart2();
             } else {
                 functions.setData2(&data[1]);
+                ESP_LOGI(LOG_CYCLE_TAG, "Got functions packet 2");
+                this->functionsArrived();
             }
-
         }
-
     }
              break;
 


### PR DESCRIPTION
# What is changing in this PR?

Adding five new optional Home Assistant controls/sensors, allowing you to view and change the Installer Functions table.  These can be enabled like this:
```
climate:
  - platform: cn105
    id: hp
    ... other sensors here ...

    functions_sensor:
      name: Installer Functions
      entity_category: DIAGNOSTIC
    functions_get_button:
      name: Get Codes
      entity_category: DIAGNOSTIC
    functions_set_button:
      name: Set Code
      entity_category: DIAGNOSTIC
    functions_set_code:
      name: Function Code
      entity_category: DIAGNOSTIC
    functions_set_value:
      name: Set Value
      entity_category: DIAGNOSTIC
```

When enabled, a "Get Codes" button is added to Home Assistant:
![image](https://github.com/user-attachments/assets/be0c1f94-665c-40ba-a367-b2880b2fb323)

Which, when pressed, returns the value of all installer functions:
![image](https://github.com/user-attachments/assets/ab6e8fb5-57fd-4041-a3be-3f8a16735efb)

To change functions, set the "Function Code" and "Set Value" sliders to the desired function number and value:
![image](https://github.com/user-attachments/assets/239112ed-364a-498d-ad9c-3bf90c569319)
And then press `Set Code`.

# Why are you making this change?
I needed to be able to change function code `101` on my PAA unit, which is Restore on Power Loss. There are also other function codes I need to be able to change, and I don't want to buy the overpriced MHK2 thermostat.

# Why this particular approach?
So, I'm not an expert at ESPHome programming and C++.  In fact, this is probably a terrible way to do this, so I don't expect my PR to be merged as-is.  Also I think I may have the values wrong -- I think it goes 1, 2, 3, not 0, 1, 2, so I probably need to change that.

I'd be very happy to have a discussion about the "proper" way to do this.  But I just could find so little documentation on how to make custom components in ESPHome, this is as far as I got.

Also, I am pretty sure the way I am doing the SET is probably wrong, it probably needs to delay between each packet or something, since that is in the original SwiCago library.

# How has this been tested?
I tested it on my PAA 24,000 BTU coil, and it seems to work fine.  It is able to read and write function codes, which is exciting!  The Swi docs mention this has only been tested on a handful of units.

# How can this be improved?
It would be awesome to read the model number of the device and then present a proper settings table, instead of these confusing and complicated codes.

Thanks very much for your work @echavet !  Your ESPHome code works PERFECTLY on my PAA and my mini-split wall unit!
![image](https://github.com/user-attachments/assets/b92aaa01-75f7-4c9a-ab3a-7a3caed0e61e)
