### PR TITLE
Silence widevane warnings if the heatpump doesn't support them

### DIFF
--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -210,7 +210,7 @@ void CN105Climate::getSettingsFromResponsePacket() {
     ESP_LOGD("Decoder", "[wideVane: %s (adj:%d)]", receivedSettings.wideVane, this->wideVaneAdj);
     if ((data[10] != 0) && (this->traits_.supports_swing_mode(climate::CLIMATE_SWING_HORIZONTAL))) {    // wideVane is not always supported
         receivedSettings.wideVane = lookupByteMapValue(WIDEVANE_MAP, WIDEVANE, 7, data[10] & 0x0F, "wideVane reading");
-        wideVaneAdj = (data[10] & 0xF0) == 0x80 ? true : false;
+        this->wideVaneAdj = (data[10] & 0xF0) == 0x80 ? true : false;        
         ESP_LOGD("Decoder", "[wideVane: %s (adj:%d)]", receivedSettings.wideVane, wideVaneAdj);
     } else {
         ESP_LOGD("Decoder", "widevane is not supported");


### PR DESCRIPTION
This should address https://github.com/echavet/MitsubishiCN105ESPHome/issues/190 for owners of ducted models (SVZ, SEZ, PVA, and PEAD air handlers). The code to handle this was already committed, just commented out. I tested it out on my own system and it silences the warnings.

For users to benefit from this change, they'll need to add
```yaml
climate:
  - platform: cn105
    supports:
      swing_mode: []
```
to their config.

