### PR TITLE
Add Celsius->Celsius mappings to provide better conversions to/from Fahrenheit

### DIFF
--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -74,6 +74,7 @@ CONF_SUB_MODE_SENSOR = "sub_mode_sensor"
 CONF_AUTO_SUB_MODE_SENSOR = "auto_sub_mode_sensor"
 CONF_HP_UP_TIME_CONNECTION_SENSOR = "hp_uptime_connection_sensor"
 CONF_USE_AS_OPERATING_FALLBACK = "use_as_operating_fallback"  # Nouvelle constante
+CONF_FAHRENHEIT_SUPPORT_MODE = "fahrenheit_compatibility"
 
 DEFAULT_CLIMATE_MODES = ["AUTO", "COOL", "HEAT", "DRY", "FAN_ONLY"]
 DEFAULT_FAN_MODES = ["AUTO", "MIDDLE", "QUIET", "LOW", "MEDIUM", "HIGH"]
@@ -232,6 +233,7 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_FUNCTIONS_SET_BUTTON): FUNCTIONS_BUTTON_SCHEMA,
         cv.Optional(CONF_FUNCTIONS_SET_CODE): FUNCTIONS_NUMBER_SCHEMA,
         cv.Optional(CONF_FUNCTIONS_SET_VALUE): FUNCTIONS_NUMBER_SCHEMA,
+        cv.Optional(CONF_FAHRENHEIT_SUPPORT_MODE): cv.boolean,
         cv.Optional(
             CONF_STAGE_SENSOR
         ): STAGE_SENSOR_CONFIG_SCHEMA,  # Modifié pour le nouveau schéma
@@ -383,6 +385,9 @@ def to_code(config):
             conf_item, min_value=1.0, max_value=3.0, step=1.0
         )
         cg.add(var.set_functions_set_value(number_var))
+
+    if CONF_FAHRENHEIT_SUPPORT_MODE in config:
+        cg.add(var.set_use_fahrenheit_support_mode(config.get(CONF_FAHRENHEIT_SUPPORT_MODE)))
 
     # --- TRAITEMENT POUR STAGE_SENSOR AVEC LA NOUVELLE OPTION ---
     if CONF_STAGE_SENSOR in config:

--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -48,21 +48,6 @@ void CN105Climate::controlDelegate(const esphome::climate::ClimateCall& call) {
         controlTemperature();
     }
 
-    if (call.get_target_temperature_low().has_value()) {
-        // Changer la température cible
-        ESP_LOGI("control", "Setting heatpump low setpoint : %.1f", *call.get_target_temperature_low());
-        this->target_temperature_low = *call.get_target_temperature_low();
-        updated = true;
-        controlTemperature();
-    }
-    if (call.get_target_temperature_high().has_value()) {
-        // Changer la température cible
-        ESP_LOGI("control", "Setting heatpump high setpoint : %.1f", *call.get_target_temperature_high());
-        this->target_temperature_high = *call.get_target_temperature_high();
-        updated = true;
-        controlTemperature();
-    }
-
     if (call.get_fan_mode().has_value()) {
         ESP_LOGD("control", "Fan change asked");
         // Changer le mode de ventilation
@@ -156,11 +141,6 @@ void CN105Climate::controlFan() {
 }
 void CN105Climate::controlTemperature() {
     float setting = this->target_temperature;
-
-    float cool_setpoint = this->target_temperature_low;
-    float heat_setpoint = this->target_temperature_high;
-    //float humidity_setpoint = this->target_humidity;
-
     if (!this->tempMode) {
         this->wantedSettings.temperature = this->lookupByteMapIndex(TEMP_MAP, 16, (int)(setting + 0.5)) > -1 ? setting : TEMP_MAP[0];
     } else {

--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -1,6 +1,12 @@
 #include "cn105.h"
 #include "Globals.h"
 
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <vector>
+#include <utility>
+
 using namespace esphome;
 
 
@@ -139,15 +145,49 @@ void CN105Climate::controlFan() {
         break;
     }
 }
+
+// Given a temperature in Celsius that was converted from Fahrenheit, converts
+// it to the Celsius value (at half-degree precision) that matches what
+// Mitsubishi thermostats would have converted the Fahrenheit value to. For
+// instance, 72°F is 22.22°C, but this function returns 22.5°C.
+static float mapCelsiusForConversionFromFahrenheit(const float c) {
+    static const auto& mapping = [] {
+        std::vector<std::pair<float, float>> v = {
+            {61, 16.0}, {62, 16.5}, {63, 17.0}, {64, 17.5}, {65, 18.0},
+            {66, 18.5}, {67, 19.0}, {68, 20.0}, {69, 21.0}, {70, 21.5},
+            {71, 22.0}, {72, 22.5}, {73, 23.0}, {74, 23.5}, {75, 24.0},
+            {76, 24.5}, {77, 25.0}, {78, 25.5}, {79, 26.0}, {80, 26.5},
+            {81, 27.0}, {82, 27.5}, {83, 28.0}, {84, 28.5}, {85, 29.0},
+            {86, 29.5}, {87, 30.0}, {88, 30.5}
+        };
+        for (auto& [k, v] : v) {
+            k = (k - 32.0f) / 1.8f;
+        }
+        return *new std::map<float, float>(v.begin(), v.end());
+    }();
+
+    // Due to vagaries of floating point math across architectures, we can't
+    // just look up `c` in the map -- we're very unlikely to find a matching
+    // value. Instead, we find the first value greater than `c`, and the
+    // next-lowest value in the map. We return whichever `c` is closer to.
+    auto it = mapping.upper_bound(c);
+    if (it == mapping.begin() || it == mapping.end()) return c;
+
+    auto prev = it;
+    --prev;
+    return c - prev->first < it->first - c ? prev->second : it->second;
+}
+
 void CN105Climate::controlTemperature() {
     float setting = this->target_temperature;
+    if (use_fahrenheit_support_mode_) {
+      setting = mapCelsiusForConversionFromFahrenheit(setting);
+    }
     if (!this->tempMode) {
         this->wantedSettings.temperature = this->lookupByteMapIndex(TEMP_MAP, 16, (int)(setting + 0.5)) > -1 ? setting : TEMP_MAP[0];
     } else {
-        setting = setting * 2;
-        setting = round(setting);
-        setting = setting / 2;
-        this->wantedSettings.temperature = setting < 10 ? 10 : (setting > 31 ? 31 : setting);
+        setting = std::round(2.0f * setting) / 2.0f;  // Round to the nearest half-degree.
+        this->wantedSettings.temperature = std::clamp(setting, 10.0f, 31.0f);
     }
 }
 
@@ -370,5 +410,12 @@ void CN105Climate::setWideVaneSetting(const char* setting) {
     }
 }
 
-
+void CN105Climate::set_remote_temperature(float setting) {
+    this->shouldSendExternalTemperature_ = true;
+    if (use_fahrenheit_support_mode_) {
+      setting = mapCelsiusForConversionFromFahrenheit(setting);
+    }
+    this->remoteTemperature_ = setting;
+    ESP_LOGD(LOG_REMOTE_TEMP, "setting remote temperature to %f", this->remoteTemperature_);
+}
 

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -180,17 +180,6 @@ namespace esphome {
         bool setFunctions(heatpumpFunctions const& functions);
 
         // helpers
-
-        float FahrenheitToCelsius(int tempF) {
-            float temp = (tempF - 32) / 1.8;
-            return ((float)round(temp * 2)) / 2;                 //Round to nearest 0.5C
-        }
-
-        int CelsiusToFahrenheit(float tempC) {
-            float temp = (tempC * 1.8) + 32;                //round up if heat, down if cool or any other mode
-            return (int)(temp + 0.5);
-        }
-
         const char* getIfNotNull(const char* what, const char* defaultValue);
 
 #ifdef TEST_MODE

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -47,6 +47,7 @@ namespace esphome {
         void set_isee_sensor(esphome::binary_sensor::BinarySensor* iSee_sensor);
         void set_stage_sensor(esphome::text_sensor::TextSensor* Stage_sensor);
         void set_use_stage_for_operating_status(bool value);
+        void set_use_fahrenheit_support_mode(bool value);
 
         void set_functions_sensor(esphome::text_sensor::TextSensor* Functions_sensor);
         void set_functions_get_button(FunctionsButton* Button);
@@ -62,6 +63,7 @@ namespace esphome {
         binary_sensor::BinarySensor* iSee_sensor_ = nullptr;
         text_sensor::TextSensor* stage_sensor_{ nullptr }; // to save ref if needed
         bool use_stage_for_operating_status_{ false };
+        bool use_fahrenheit_support_mode_ = false;
         text_sensor::TextSensor* Functions_sensor_ = nullptr;
         FunctionsButton* Functions_get_button_ = nullptr;
         FunctionsButton* Functions_set_button_ = nullptr;

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -64,9 +64,3 @@ void CN105Climate::set_update_interval(uint32_t update_interval) {
     this->update_interval_ = update_interval;
     this->autoUpdate = (update_interval != 0);
 }
-
-void CN105Climate::set_remote_temperature(float setting) {
-    this->shouldSendExternalTemperature_ = true;
-    this->remoteTemperature_ = setting;
-    ESP_LOGD(LOG_REMOTE_TEMP, "setting remote temperature to %f", this->remoteTemperature_);
-}

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -151,3 +151,9 @@ void CN105Climate::set_auto_sub_mode_sensor(esphome::text_sensor::TextSensor* Au
 void CN105Climate::set_hp_uptime_connection_sensor(uptime::HpUpTimeConnectionSensor* hp_up_connection_sensor) {
     this->hp_uptime_connection_sensor_ = hp_up_connection_sensor;
 }
+
+void CN105Climate::set_use_fahrenheit_support_mode(bool value) {
+    this->use_fahrenheit_support_mode_ = value;
+    ESP_LOGI(TAG, "Fahrenheit compatibility mode enabled: ", value ? "true" : "false");
+}
+


### PR DESCRIPTION
Fixes https://github.com/echavet/MitsubishiCN105ESPHome/issues/272.

Because Celsius and Fahrenheit do not evenly correspond (Δ1°F = Δ0.56°C), Mitsubishi has implemented a custom translation between the two based on a lookup table for the ease of controlling their heat pumps (which use Celsius internally) from thermostats set to Fahrenheit.

My first attempt at solving this, as suggested from the issue mentioned above, was to use custom C<->F temperature conversion functions that mirrored Mitsubishi's mappings. However, I discovered that because ESPHome advertises itself to Home Assistant as only supporting Celsius (https://github.com/home-assistant/core/blob/dev/homeassistant/components/esphome/climate.py#L133C5-L133C55), Home Assistant will convert all Fahrenheit temperatures to Celsius before sending them to ESPHome. This means that on-device temperatures are never Fahrenheit, always Celsius.

Instead, we have to create mappings from Celsius (the real unit) to and from Celsius (the adjusted scale used by Mitsubishi). For instance, if Home Assistant has 74°F, that's sent to ESPHome as 23.3°C, and the functions in this PR translate that to 23.5°C before it's sent to the air handler. Similarly, if we get 23.3°C from the air handler, that's translated to 23.5°C before it's sent to the user, so it will properly converted to 74°F.

Lookup tables taken from from code written by @dsstewa in https://github.com/gysmo38/mitsubishi2MQTT/pull/272, with permission. More information about the tables can be found there.