### PR TITLE
Resolve issue #311

### DIFF
--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -154,6 +154,6 @@ void CN105Climate::set_hp_uptime_connection_sensor(uptime::HpUpTimeConnectionSen
 
 void CN105Climate::set_use_fahrenheit_support_mode(bool value) {
     this->use_fahrenheit_support_mode_ = value;
-    ESP_LOGI(TAG, "Fahrenheit compatibility mode enabled: ", value ? "true" : "false");
+    ESP_LOGI(TAG, "Fahrenheit compatibility mode enabled: %s", value ? "true" : "false");
 }
 


### PR DESCRIPTION
Resolve https://github.com/echavet/MitsubishiCN105ESPHome/issues/311 by adding formatting argument to log, which blocks compiling on some versions of esp-idf.