### PR TITLE
Only set default vane positions if swing was previously enabled

### DIFF
--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -105,10 +105,12 @@ void CN105Climate::controlSwing() {
 
     switch (this->swing_mode) {
     case climate::CLIMATE_SWING_OFF:
-        // When swing is turned OFF, unconditionally set vanes to a default static position.
-        // This ensures that any and all swinging motion stops, regardless of the previous state.
-        this->setVaneSetting("AUTO");
-        if (wideVaneSupported) {
+        // When swing is turned OFF, conditionally set vanes to a default static position.
+        // This only sets default position if swing was previously enabled
+        if (strcmp(currentSettings.vane, "SWING") == 0) {
+            this->setVaneSetting("AUTO");
+        }
+        if (wideVaneSupported && strcmp(currentSettings.wideVane, "SWING") == 0) {
             this->setWideVaneSetting("|");
         }
         break;


### PR DESCRIPTION
Updated with check for if widevane is available and conditional swing off. If default values are set when swing is not enabled then it breaks scenes that have defined vane and widevane positions.