### PR TITLE
Update README with clarification to the UART issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > ```
 
 > [!WARNING]  
-> Due to a change in ESPHome 2025.8.0, some users are facing UART connection issues. Forcing the firmware esphome version to a previous release AND cold booting the device solves the issue. Alternative is to force ESP32 IDF version to 5.4.1.
+> Due to a change in ESPHome 2025.8.0, some users are facing UART connection issues after a cold boot. Forcing the firmware esphome version to a previous release (2025.7.5 and below) solves the issue (no cold boot required). Alternative is to force ESP32 IDF version to 5.4.0. Note that OTA updates to 2025.8.0+ may work but can break after a subsequent cold boot.
 >
 > *"commit 116c91e9c5fc6d0d32191bd4e6d6e406e2bff6bf Author: Jonathan Swoboda <154711427+swoboda1337@users.noreply.github.com> Date:   Tue Jul 22 19:15:31 2025 -0400*
 > 
@@ -22,7 +22,7 @@
 >   board: esp32-s3-devkitc-1  
 >   framework:
 >     type: esp-idf
->     version: 5.4.1
+>     version: 5.4.0
 >   variant: esp32s3
 >   flash_size: 8MB
 > ```


### PR DESCRIPTION
Here are some changes to clarify + correct the instructions related to the UART issue:

- the broken release of ESP-IDF is actually version 5.4.1.
  - ESPHome had jumped from ESP-IDF v5.3.2 to v5.4.2
  - I did test the YAML code as written and confirmed v5.4.1 is broken and v5.4.0 works.
- clarified the part about cold booting.  Cold booting is ONLY required to get the darn thing to break.  This has confused a lot of folks, including me.  Hopefully the new wording is both accurate and not too verbose.

Thank you so much @echavet.  :)