### PR TITLE
Fix typo

### DIFF
--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -146,8 +146,8 @@ void CN105Climate::controlDelegate(const esphome::climate::ClimateCall& call) {
             }
         }
         updated = true;
-        ESP_LOGD("control", "sanitizing dual setpoints..."),
-            this->sanitizeDualSetpoints();
+        ESP_LOGD("control", "sanitizing dual setpoints...");
+        this->sanitizeDualSetpoints();
         ESP_LOGD("control", "sanitized dual setpoints: low: %.1f - high: %.1f", this->target_temperature_low, this->target_temperature_high);
         this->controlTemperature();
         ESP_LOGD("control", "controlled temperature to: %.1f", this->wantedSettings.temperature);


### PR DESCRIPTION
Correct syntax issue that caused build to fail (replaced trailing comma with semicolon)