### PR TITLE
Fix: Immediate climate action updates when use_as_operating_fallback is enabled

### DIFF
--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -165,6 +165,13 @@ void CN105Climate::getPowerFromResponsePacket() {
         if (!this->currentSettings.stage || strcmp(receivedSettings.stage, this->currentSettings.stage) != 0) {
             this->currentSettings.stage = receivedSettings.stage;
             this->stage_sensor_->publish_state(receivedSettings.stage);
+
+            // If using stage as operating fallback, update action immediately when stage changes
+            // and publish to Home Assistant
+            if (this->use_stage_for_operating_status_) {
+                this->updateAction();
+                this->publish_state();
+            }
         }
     }
     if (this->Sub_mode_sensor_ != nullptr && (!this->currentSettings.sub_mode || strcmp(receivedSettings.sub_mode, this->currentSettings.sub_mode) != 0)) {


### PR DESCRIPTION
## Summary
Fixes #428 

When `use_as_operating_fallback: true` is enabled on the stage sensor, the climate entity's `hvac_action` now updates immediately when the stage changes, instead of waiting several minutes for other settings to change.

## Changes Made
Added immediate `updateAction()` and `publish_state()` calls in `components/cn105/hp_readings.cpp` after stage sensor updates when `use_stage_for_operating_status_` is enabled.

## Problem Solved
Previously, the stage sensor would correctly publish state changes (IDLE → LOW → GENTLE), but the climate entity's action (IDLE/HEATING/COOLING) would remain stale for several minutes because `updateAction()` was only called when other settings changed.

This was particularly problematic for ducted units using `use_as_operating_fallback`:
- On heating startup: stage shows LOW/GENTLE, but climate shows IDLE
- On heating shutdown: stage shows IDLE, but climate shows HEATING  
- Delays of several minutes before climate action synced with actual operation

## Technical Details
The fix ensures:
1. `updateAction()` recalculates the climate action based on the current stage
2. `publish_state()` immediately notifies Home Assistant of the change

The `publish_state()` call is crucial - without it, the ESPHome device's web interface shows the correct state, but Home Assistant doesn't receive the update.

## Testing
Tested on Mitsubishi PVFY-L54NAMU-A ducted unit with Xiao ESP32C6:
- ✅ Heating mode: Climate action updates immediately when stage changes
- ✅ Cooling mode: Climate action updates immediately when stage changes
- ✅ Both ESPHome web interface and Home Assistant show synchronized state

## Related
Related to #277 which introduced the `use_as_operating_fallback` feature.