### PR TITLE
Remove project description from warning block

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@
 >   variant: esp32s3
 >   flash_size: 8MB
 > ```
->
-> This project is a firmware for ESP32 microcontrollers supporting UART communication via the CN105 Mitsubishi connector. Its purpose is to enable complete control of a compatible Mitsubishi heat pump through Home Assistant, a web interface, or any MQTT client.
+
+This project is a firmware for ESP32 microcontrollers supporting UART communication via the CN105 Mitsubishi connector. Its purpose is to enable complete control of a compatible Mitsubishi heat pump through Home Assistant, a web interface, or any MQTT client.
 
 It uses the ESPHome framework and is compatible with the Arduino framework and ESP-IDF.
 


### PR DESCRIPTION
The project's description has been (accidentally I assume) moved into the warning block, that it isn't really relevant to. This moves it back out.