### PR TITLE
fix #437: check available SOC UART numbers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ snapshot.sh
 myfirmware/.gitignore
 .vscode/*
 .vscode/settings.json
+hp-esp32-arduino.yaml

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -1,6 +1,7 @@
 
 #include "cn105.h"
 #ifdef USE_ESP32
+#include "soc/soc_caps.h"
 #include <driver/uart.h>
 #include <driver/gpio.h>
 #include <freertos/FreeRTOS.h>
@@ -346,7 +347,11 @@ void CN105Climate::force_low_level_uart_reinit() {
 #ifdef USE_ESP32
     // Réinit basse couche: reconfigurer le contrôleur utilisé par UARTComponent
     // On utilise le port passé par set_uart_port (fallback UART0 si inconnu)
-    const uart_port_t port = (this->uart_port_ == 1) ? UART_NUM_1 : (this->uart_port_ == 2) ? UART_NUM_2 : UART_NUM_0;
+    const uart_port_t port = (this->uart_port_ == 1) ? UART_NUM_1 :
+#if SOC_UART_NUM > 2
+        (this->uart_port_ == 2) ? UART_NUM_2 :
+#endif
+        UART_NUM_0;
 
     ESP_LOGI(TAG, "Forcing low-level UART reinit on port %d (tx=%d, rx=%d)", (int)port, this->tx_pin_, this->rx_pin_);
 


### PR DESCRIPTION
fix #437 : Modify CN105 climate control UART handling to support dynamic UART port configuration based on available SOC UART numbers.
