### PR TITLE
Add ifdef for UART_NUM_2

### DIFF
--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -348,7 +348,7 @@ void CN105Climate::force_low_level_uart_reinit() {
     // Réinit basse couche: reconfigurer le contrôleur utilisé par UARTComponent
     // On utilise le port passé par set_uart_port (fallback UART0 si inconnu)
     const uart_port_t port = (this->uart_port_ == 1) ? UART_NUM_1 :
-#ifdef (UART_NUM_2)
+#ifdef UART_NUM_2
         (this->uart_port_ == 2) ? UART_NUM_2 :
 #endif
         UART_NUM_0;


### PR DESCRIPTION
Added #ifdef UART_NUM_2 guard to ensure compilation on SoCs that only define UART0–UART1 (C3, C6, ...). No behavior change for SoCs with three UARTs.