### PR TITLE
Add horizontal_vane_mode option to filter horizontal vane select options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mitsubishi CN105 ESPHome
 
-> [!WARNING]  
+> [!WARNING]
 > Due to a change in ESPHome 2025.2.0, some users are reporting build problems related to the loading of the `uptime_seconds_sensor` class. If you get a compile error for this reason, manually add an uptime sensor to your YAML configuration as below, clean your build files, and recompile. Once the root cause is identified this note will be removed.
 >
 > ```yaml
@@ -9,14 +9,14 @@
 >     name: Uptime
 > ```
 
-> [!WARNING]  
+> [!WARNING]
 > Due to a change in ESPHome 2025.8.0, some users are facing UART connection issues after a cold boot. Forcing the firmware esphome version to a previous release (2025.7.5 and below) solves the issue (no cold boot required). Alternative is to force ESP32 IDF version to 5.4.0. Note that OTA updates to 2025.8.0+ may work but can break after a subsequent cold boot.
 >
 > _"commit 116c91e9c5fc6d0d32191bd4e6d6e406e2bff6bf Author: Jonathan Swoboda <154711427+swoboda1337@users.noreply.github.com> Date: Tue Jul 22 19:15:31 2025 -0400_
 >
 > _Bump ESP32 IDF version to 5.4.2 and Arduino version to 3.2.1 (#9770)"_
 >
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Temporary fix included: This component now implements a fallback low-level UART reinitialization that triggers only if the initial (normal) connection fails at boot. It reconfigures the UART controller linked to your `uart:` block (clock source, reapplies baudrate, RX pull-up, flush, etc.). No YAML `on_boot` workaround is required. This aims to mitigate ESP-IDF 5.4.x regressions observed on some ESP32 at low baud (2400, 8E1).
 >
 > If this fallback still doesn’t work on your hardware, you can temporarily force ESP‑IDF 5.4.0 in your YAML:
@@ -291,6 +291,10 @@ climate:
       mode: [AUTO, COOL, HEAT, DRY, FAN_ONLY]
       fan_mode: [AUTO, QUIET, LOW, MEDIUM, HIGH]
       swing_mode: ["OFF", VERTICAL]
+      # Specify which options to display in horizontal_vane_select dropdown
+      # Defaults to all options: ["←←", "←", "|", "→", "→→", "←→", "SWING", "AIRFLOW CONTROL"]
+      # Example to hide "←→" and "AIRFLOW CONTROL" if not supported by your unit:
+      horizontal_vane_mode: ["←←", "←", "|", "→", "→→", SWING]
 ```
 
 > [!TIP]
@@ -353,7 +357,7 @@ This minimal configuration includes the basic components necessary for the firmw
 <details>
 
 <summary>Minimal Configuration</summary>
-  
+
 ```yaml
 esphome:
   name: heatpump-1
@@ -430,7 +434,8 @@ password: !secret fallback_password
 
 captive_portal:
 
-````
+```
+
 </details>
 
 ## Example Configuration - Complete
@@ -664,7 +669,7 @@ climate:
       name: Runtime Hours
       entity_category: diagnostic
       disabled_by_default: true
-````
+```
 
 </details>
 

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -42,7 +42,7 @@ namespace esphome {
         CN105Climate(uart::UARTComponent* hw_serial);
 
         void set_vertical_vane_select(VaneOrientationSelect* vertical_vane_select);
-        void set_horizontal_vane_select(VaneOrientationSelect* horizontal_vane_select);
+        void set_horizontal_vane_select(VaneOrientationSelect* horizontal_vane_select, const std::vector<std::string>& options = {});
         void set_airflow_control_select(VaneOrientationSelect* airflow_control_select);
         void set_compressor_frequency_sensor(esphome::sensor::Sensor* compressor_frequency_sensor);
         void set_input_power_sensor(esphome::sensor::Sensor* input_power_sensor);
@@ -95,6 +95,7 @@ namespace esphome {
             nullptr;  // Select to store manual position of vertical swing
         VaneOrientationSelect* horizontal_vane_select_ =
             nullptr;  // Select to store manual position of horizontal swing
+        std::vector<std::string> horizontal_vane_options_strings_;  // Store strings for horizontal vane options
         VaneOrientationSelect* airflow_control_select_ =
             nullptr;
         sensor::Sensor* compressor_frequency_sensor_ =

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -1,4 +1,6 @@
 #include "cn105.h"
+#include <algorithm>
+#include <esphome/core/helpers.h>
 
 using namespace esphome;
 
@@ -34,14 +36,29 @@ void CN105Climate::set_vertical_vane_select(
 }
 
 void CN105Climate::set_horizontal_vane_select(
-    VaneOrientationSelect* horizontal_vane_select) {
+    VaneOrientationSelect* horizontal_vane_select, const std::vector<std::string>& options) {
     this->horizontal_vane_select_ = horizontal_vane_select;
 
-    // builds option list from SwiCago wideVaneMap
-    this->horizontal_vane_select_->traits.set_options({
-        WIDEVANE_MAP[0], WIDEVANE_MAP[1], WIDEVANE_MAP[2], WIDEVANE_MAP[3],
-        WIDEVANE_MAP[4], WIDEVANE_MAP[5], WIDEVANE_MAP[6], WIDEVANE_MAP[7]
-        });
+    // Use provided options if not empty, and filter out any options that are not in WIDEVANE_MAP to ensure validity,
+    // otherwise use all options from WIDEVANE_MAP
+    if (!options.empty()) {
+        this->horizontal_vane_options_strings_.clear();
+        for (const auto& option : options) {
+            if (std::find(std::begin(WIDEVANE_MAP), std::end(WIDEVANE_MAP), option) != std::end(WIDEVANE_MAP)) {
+                this->horizontal_vane_options_strings_.push_back(option);
+            }
+        }
+    } else {
+        this->horizontal_vane_options_strings_.assign(std::begin(WIDEVANE_MAP), std::end(WIDEVANE_MAP));
+    }
+
+    // Build FixedVector of const char* for set_options
+    FixedVector<const char*> fixedOptions;
+    fixedOptions.init(this->horizontal_vane_options_strings_.size());
+    for (const auto& str : this->horizontal_vane_options_strings_) {
+        fixedOptions.push_back(str.c_str());
+    }
+    this->horizontal_vane_select_->traits.set_options(fixedOptions);
 
     this->horizontal_vane_select_->setCallbackFunction([this](const char* setting) {
         ESP_LOGD("EVT", "wideVane.control() -> Demande un chgt de réglage de la wideVane: %s", setting);


### PR DESCRIPTION
Adds a new `horizontal_vane_mode` configuration option in the `supports` section that allows us to specify which options should be displayed in the `horizontal_vane_select` dropdown. Resolves #377.

### Motivation
Some Mitsubishi units (like my MSZ-AY35VGK and MSZ-AY25VGK) do not support all horizontal vane options, like the `AIRFLOW CONTROL` and `←→` options (related to the I-See feature). This option allows us to remove unsupported options from the dropdown.

### Implementation
- New configuration option: `supports.horizontal_vane_mode` - accepts a list of strings
- If not specified, all options from `WIDEVANE_MAP` are used (C++ is source of truth)
- Modified `set_horizontal_vane_select()` to accept optional `std::vector<std::string>` parameter
- Uses `FixedVector<const char*>` to pass options to ESPHome's `set_options()` API

### Design Decision
I chose to add a dedicated `horizontal_vane_mode` option in `supports` rather than conditionally filtering based on the presence of `airflow_control_select` or `isee_sensor` entities. This approach provides maximum flexibility:
- Users can keep the `airflow_control_select` or `isee_sensor` entities while hiding specific options from `horizontal_vane_select`
- Users can customize the order of options in the dropdown

### Example
```yaml
supports:
  horizontal_vane_mode: ["←←", "←", "|", "→", "→→", "SWING"]
```