### PR TITLE
Fix CN105 swing control null checks

### DIFF
--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -250,15 +250,17 @@ void CN105Climate::control(const esphome::climate::ClimateCall& call) {
 void CN105Climate::controlSwing() {
     // Check if horizontal vane (wideVane) is supported by this unit at the beginning.
     bool wideVaneSupported = this->traits_.supports_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
+    bool vane_is_swing = (this->currentSettings.vane != nullptr) && (strcmp(this->currentSettings.vane, "SWING") == 0);
+    bool wide_is_swing = (this->currentSettings.wideVane != nullptr) && (strcmp(this->currentSettings.wideVane, "SWING") == 0);
 
     switch (this->swing_mode) {
     case climate::CLIMATE_SWING_OFF:
         // When swing is turned OFF, conditionally set vanes to a default static position.
         // This only sets default position if swing was previously enabled
-        if (strcmp(currentSettings.vane, "SWING") == 0) {
+        if (vane_is_swing) {
             this->setVaneSetting("AUTO");
         }
-        if (wideVaneSupported && strcmp(currentSettings.wideVane, "SWING") == 0) {
+        if (wideVaneSupported && wide_is_swing) {
             this->setWideVaneSetting("|");
         }
         break;
@@ -269,7 +271,7 @@ void CN105Climate::controlSwing() {
         // If horizontal swing was also on AND is supported, turn it off to a default static position.
         // This correctly handles switching from BOTH to VERTICAL, while preserving any user's
         // static horizontal setting if it wasn't swinging.
-        if (wideVaneSupported && strcmp(currentSettings.wideVane, "SWING") == 0) {
+        if (wideVaneSupported && wide_is_swing) {
             this->setWideVaneSetting("|");
         }
         break;
@@ -278,7 +280,7 @@ void CN105Climate::controlSwing() {
         // If vertical swing was on, turn it off to a default static position.
         // This correctly handles switching from BOTH to HORIZONTAL, while preserving any user's
         // static vertical setting if it wasn't swinging.
-        if (strcmp(currentSettings.vane, "SWING") == 0) {
+        if (vane_is_swing) {
             this->setVaneSetting("AUTO");
         }
         // Turn on horizontal swing, but only if the unit supports it.


### PR DESCRIPTION
## Summary
- Guard CN105 swing logic against null vane strings.
- Prevent boot-time crashes caused by `strcmp()` dereferencing `nullptr`.
- Allow meta thermostat + dual-setpoint logic to initialize without reboot loops.

## Details
`currentSettings.vane` and `currentSettings.wideVane` are null until the heat pump reports its first packet. The old `controlSwing()` unconditionally called `strcmp()` on those pointers, so the very first preset refresh dereferenced null and rebooted the ESP before Wi-Fi/API came up. It now computes `vane_is_swing`/`wide_is_swing` booleans that check for null before comparing, and reuse those flags across the switch branches. Behaviour is unchanged once the strings exist; the fix simply removes the crash so the device stays online.