### PR TITLE
Add dead band support to help eliminate short cycling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,35 @@ api:
         - lambda: "id(hp).set_remote_temperature(0);"
 ```
 
+## Short cycle mitigation
+
+Short cycling happens when a heat pump repeatedly shuts off and turns back on because the room temperature briefly exceeds the set point. Instead of settling into a steady, low-output “cruise” mode, the system keeps restarting. This creates temperature swings, increases energy use, and puts extra wear on the compressor. Multisplit systems are especially prone to this because their minimum output is relatively high, so small rooms can be overheated very quickly.
+
+Every heating or cooling cycle begins with a compressor warm-up period that typically lasts 5 to 20 minutes. During this phase, the system runs at a higher output while it re-establishes suction and discharge pressures and circulates oil. Only after warm-up can the compressor ramp down toward its minimum modulation. If the room overshoots the set point before the system reaches that stable, low-output state, the unit will shut off and restart, causing short cycling. In some cases, the heat pump can maintain equilibrium once it is modulating, but not during the warm-up phase.
+
+Short cycling can be reduced with three strategies:
+
+1. Use an external temperature sensor and place it far from the indoor head. The opposite end of the room warms more slowly, preventing premature overshoot.
+
+2. Lower the fan speed to its minimum. Higher airflow cools the coil, which makes the compressor drive harder and increases output, pushing you toward overshoot.
+
+3. Increase the deadband (overshoot tolerance) beyond the factory 0.5 °C. The room may warm slightly above the set point at the start of a cycle, but once the system reaches cruise mode, output drops and the temperature stabilizes near the target. 
+
+** Note that setting the overshoot threshold and tolerance values requires an external temperature sensor **
+
+Configuration example
+```yaml
+climate:
+  - platform: cn105
+    # This should generally remain 0.5 degrees C. It is the point above the setpoint where the system would normally turn off.
+    overshoot_threshold: 0.5
+
+    # Additional tolerance to prevent short cycling. Increase only as much as needed.
+    overshoot_tolerance: 1
+```
+
+With a 22 °C set point, the unit would normally shut off at 22.5 °C. Adding an overshoot_tolerance of 1 raises the cutoff to 23.5 °C. For example, if the actual room temperature reaches 23.0 °C, the system will continue to report 22.5 °C internally, staying in heating mode. Only if the true room temperature reaches 24.0 °C, which is outside the expanded deadband, does the displayed temperature jump to the real value and allow the unit to turn off.
+
 ## Diagnostic Sensors
 
 ### Outside Air Temperature

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -85,6 +85,8 @@ CONF_CIRCULATOR_SWITCH = "circulator_switch"
 
 # Support explicite du DUAL setpoint via YAML
 CONF_DUAL_SETPOINT = "dual_setpoint"
+CONF_OVERSHOOT_THRESHOLD = "overshoot_threshold"
+CONF_OVERSHOOT_TOLERANCE = "overshoot_tolerance"
 
 DEFAULT_CLIMATE_MODES = ["AUTO", "COOL", "HEAT", "DRY", "FAN_ONLY"]
 DEFAULT_FAN_MODES = ["AUTO", "MIDDLE", "QUIET", "LOW", "MEDIUM", "HIGH"]
@@ -273,6 +275,8 @@ CONFIG_SCHEMA = (
             cv.Optional(
                 CONF_STAGE_SENSOR
             ): STAGE_SENSOR_CONFIG_SCHEMA,  # Modifié pour le nouveau schéma
+            cv.Optional(CONF_OVERSHOOT_THRESHOLD): cv.float_,
+            cv.Optional(CONF_OVERSHOOT_TOLERANCE): cv.float_,
             cv.Optional(CONF_SUB_MODE_SENSOR): SUB_MODE_SENSOR_SCHEMA,
             cv.Optional(CONF_AUTO_SUB_MODE_SENSOR): AUTO_SUB_MODE_SENSOR_SCHEMA,
             cv.Optional(CONF_REMOTE_TEMP_TIMEOUT, default="never"): cv.All(
@@ -485,6 +489,12 @@ def to_code(config):
                 config.get(CONF_FAHRENHEIT_SUPPORT_MODE)
             )
         )
+
+    if CONF_OVERSHOOT_THRESHOLD in config:
+        cg.add(var.set_overshoot_threshold(config[CONF_OVERSHOOT_THRESHOLD]))
+
+    if CONF_OVERSHOOT_TOLERANCE in config:
+        cg.add(var.set_overshoot_tolerance(config[CONF_OVERSHOOT_TOLERANCE]))
 
     # --- TRAITEMENT POUR STAGE_SENSOR AVEC LA NOUVELLE OPTION ---
     if CONF_STAGE_SENSOR in config:

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -53,6 +53,8 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
     this->air_purifier_switch_ = nullptr;
     this->night_mode_switch_ = nullptr;
     this->circulator_switch_ = nullptr;
+    this->overshoot_threshold_ = 0.0f;
+    this->overshoot_tolerance_ = 0.0f;
 
     this->powerRequestWithoutResponses = 0;     // power request is not supported by all heatpump #112
 

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -56,6 +56,8 @@ namespace esphome {
         void set_air_purifier_switch(HVACOptionSwitch* air_purifier_switch);
         void set_night_mode_switch(HVACOptionSwitch* night_mode_switch);
         void set_circulator_switch(HVACOptionSwitch* circulator_switch);
+        void set_overshoot_threshold(float value);
+        void set_overshoot_tolerance(float value);
 
         void set_functions_sensor(esphome::text_sensor::TextSensor* Functions_sensor);
         void set_functions_get_button(FunctionsButton* Button);
@@ -154,6 +156,7 @@ namespace esphome {
         void set_remote_temperature(float);
         void sendRemoteTemperature();
         void sendWantedRunStates();
+        float getDeadbandAdjustedTemperature(float remoteTemperature);
 
         void set_remote_temp_timeout(uint32_t timeout);
 
@@ -361,6 +364,8 @@ namespace esphome {
 
         uint32_t remote_temp_timeout_;
         uint32_t debounce_delay_;
+        float overshoot_threshold_{ 0.0f };
+        float overshoot_tolerance_{ 0.0f };
 
         int baud_ = 0;
         int tx_pin_ = -1;

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -230,3 +230,13 @@ void CN105Climate::set_use_fahrenheit_support_mode(bool value) {
     this->fahrenheitSupport_.setUseFahrenheitSupportMode(value);
     ESP_LOGI(TAG, "Fahrenheit compatibility mode enabled: %s", value ? "true" : "false");
 }
+
+void CN105Climate::set_overshoot_threshold(float value) {
+    this->overshoot_threshold_ = value;
+    ESP_LOGI(TAG, "Overshoot threshold set to %.3f", value);
+}
+
+void CN105Climate::set_overshoot_tolerance(float value) {
+    this->overshoot_tolerance_ = value;
+    ESP_LOGI(TAG, "Overshoot tolerance set to %.3f", value);
+}


### PR DESCRIPTION
The factory configuration of a Mitsubishi minisplit is to turn itself off if the temperature overshoots by 0.5 °C. This merge request makes that value configurable by introducing a deadband, and by reporting the edge of the deadband that is closest to the setpoint to the heat pump. If the actual temperature falls outside the deadband, the actual temperature is reported to the heat pump instead.

I realized that even though Mitsubishi heat pumps are variable speed and can modulate, the lowest modulation levels are only available after the unit completes its warmup phase, which takes around 15 minutes. If the temperature overshoots during this warmup period, the heat pump cannot modulate down and short cycling will occur. Once the 15 minutes have passed, the minimum heat output drops significantly, which allows the heat pump to cruise at a low, steady output and keep the room at equilibrium.

This is still experimental, but so far it has been working well. Previously my Emporia Vue would report power usage bouncing between 0 W and 1500 W. Now it fluctuates in a narrow band between about 580 W and 660 W.

Known issues and limitations:
- The room temperature is currently idling about 1 °F above the setpoint. I considered adding logic to apply an offset and hide this from Home Assistant, but that would cause the handheld remotes to read 1 °F off from the true setpoint.
- If your minisplit is significantly oversized for the room, this is unlikely to help much. There is still a hard minimum BTU output. If that minimum output is greater than the room’s heat demand, software changes cannot fully solve the problem.
- An external temperature sensor is a mandatory requirement. We cannot fake data coming from the internal sensor.