### PR TITLE
Fix fahrenheit support

### DIFF
--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -68,12 +68,12 @@ bool CN105Climate::processModeChange(const esphome::climate::ClimateCall& call) 
 
 void CN105Climate::handleDualSetpointBoth(float low, float high) {
     ESP_LOGD("control", "handleDualSetpointBoth - low: %.1f, high: %.1f", low, high);
-    this->target_temperature_low = low;
-    this->target_temperature_high = high;
+    this->setTargetTemperatureLow(low);
+    this->setTargetTemperatureHigh(high);
     this->last_dual_setpoint_side_ = 'N';
     this->last_dual_setpoint_change_ms_ = CUSTOM_MILLIS;
-    this->currentSettings.dual_low_target = this->target_temperature_low;
-    this->currentSettings.dual_high_target = this->target_temperature_high;
+    this->currentSettings.dual_low_target = this->getTargetTemperatureLow();
+    this->currentSettings.dual_high_target = this->getTargetTemperatureHigh();
 }
 
 void CN105Climate::handleDualSetpointLowOnly(float low) {
@@ -82,20 +82,20 @@ void CN105Climate::handleDualSetpointLowOnly(float low) {
         ESP_LOGD("control", "IGNORED low setpoint due to UI anti-rebound after high change");
         return;
     }
-    if (!std::isnan(this->target_temperature_low) && fabsf(low - this->target_temperature_low) < 0.05f) {
+    if (!std::isnan(this->getTargetTemperatureLow()) && fabsf(low - this->getTargetTemperatureLow()) < 0.05f) {
         ESP_LOGD("control", "IGNORED low setpoint: no effective change vs current low target");
         return;
     }
-    this->target_temperature_low = low;
+    this->setTargetTemperatureLow(low);
     if (this->mode == climate::CLIMATE_MODE_AUTO) {
         const float amplitude = 4.0f;
-        this->target_temperature_high = this->target_temperature_low + amplitude;
-        ESP_LOGD("control", "mode auto: sliding high to preserve amplitude %.1f => [%.1f - %.1f]", amplitude, this->target_temperature_low, this->target_temperature_high);
+        this->setTargetTemperatureHigh(this->getTargetTemperatureLow() + amplitude);
+        ESP_LOGD("control", "mode auto: sliding high to preserve amplitude %.1f => [%.1f - %.1f]", amplitude, this->getTargetTemperatureLow(), this->getTargetTemperatureHigh());
     }
     this->last_dual_setpoint_side_ = 'L';
     this->last_dual_setpoint_change_ms_ = CUSTOM_MILLIS;
-    this->currentSettings.dual_low_target = this->target_temperature_low;
-    this->currentSettings.dual_high_target = this->target_temperature_high;
+    this->currentSettings.dual_low_target = this->getTargetTemperatureLow();
+    this->currentSettings.dual_high_target = this->getTargetTemperatureHigh();
 }
 
 void CN105Climate::handleDualSetpointHighOnly(float high) {
@@ -104,46 +104,46 @@ void CN105Climate::handleDualSetpointHighOnly(float high) {
         ESP_LOGD("control", "ignored high setpoint due to UI anti-rebound after low change");
         return;
     }
-    if (!std::isnan(this->target_temperature_high) && fabsf(high - this->target_temperature_high) < 0.05f) {
+    if (!std::isnan(this->getTargetTemperatureHigh()) && fabsf(high - this->getTargetTemperatureHigh()) < 0.05f) {
         ESP_LOGD("control", "ignored high setpoint: no effective change vs current high target");
         return;
     }
-    this->target_temperature_high = high;
+    this->setTargetTemperatureHigh(high);
     if (this->mode == climate::CLIMATE_MODE_AUTO) {
         const float amplitude = 4.0f;
-        this->target_temperature_low = this->target_temperature_high - amplitude;
-        ESP_LOGD("control", "mode auto: sliding low to preserve amplitude %.1f => [%.1f - %.1f]", amplitude, this->target_temperature_low, this->target_temperature_high);
+        this->setTargetTemperatureLow(this->getTargetTemperatureHigh() - amplitude);
+        ESP_LOGD("control", "mode auto: sliding low to preserve amplitude %.1f => [%.1f - %.1f]", amplitude, this->getTargetTemperatureLow(), this->getTargetTemperatureHigh());
     }
     this->last_dual_setpoint_side_ = 'H';
     this->last_dual_setpoint_change_ms_ = CUSTOM_MILLIS;
-    this->currentSettings.dual_low_target = this->target_temperature_low;
-    this->currentSettings.dual_high_target = this->target_temperature_high;
+    this->currentSettings.dual_low_target = this->getTargetTemperatureLow();
+    this->currentSettings.dual_high_target = this->getTargetTemperatureHigh();
 }
 
 void CN105Climate::handleSingleTargetInAutoOrDry(float requested) {
     ESP_LOGD("control", "handleSingleTargetInAutoOrDry - SINGLE: %.1f", requested);
     if (this->mode == climate::CLIMATE_MODE_AUTO) {
         const float half_span = 2.0f;
-        this->target_temperature_low = requested - half_span;
-        this->target_temperature_high = requested + half_span;
+        this->setTargetTemperatureLow(requested - half_span);
+        this->setTargetTemperatureHigh(requested + half_span);
         this->last_dual_setpoint_side_ = 'N';
         this->last_dual_setpoint_change_ms_ = CUSTOM_MILLIS;
-        this->currentSettings.dual_low_target = this->target_temperature_low;
-        this->currentSettings.dual_high_target = this->target_temperature_high;
-        this->target_temperature = requested;
-        ESP_LOGD("control", "AUTO received single target: median=%.1f => [%.1f - %.1f]", requested, this->target_temperature_low, this->target_temperature_high);
+        this->currentSettings.dual_low_target = this->getTargetTemperatureLow();
+        this->currentSettings.dual_high_target = this->getTargetTemperatureHigh();
+        this->setTargetTemperature(requested);
+        ESP_LOGD("control", "AUTO received single target: median=%.1f => [%.1f - %.1f]", requested, this->getTargetTemperatureLow(), this->getTargetTemperatureHigh());
     }
     if (this->mode == climate::CLIMATE_MODE_DRY) {
-        this->target_temperature_high = requested;
-        if (std::isnan(this->target_temperature_low)) {
-            this->target_temperature_low = requested;
+        this->setTargetTemperatureHigh(requested);
+        if (std::isnan(this->getTargetTemperatureLow())) {
+            this->setTargetTemperatureLow(requested);
         }
         this->last_dual_setpoint_side_ = 'H';
         this->last_dual_setpoint_change_ms_ = CUSTOM_MILLIS;
-        this->currentSettings.dual_low_target = this->target_temperature_low;
-        this->currentSettings.dual_high_target = this->target_temperature_high;
-        this->target_temperature = requested;
-        ESP_LOGD("control", "DRY received single target: high=%.1f (low now %.1f)", this->target_temperature_high, this->target_temperature_low);
+        this->currentSettings.dual_low_target = this->getTargetTemperatureLow();
+        this->currentSettings.dual_high_target = this->getTargetTemperatureHigh();
+        this->setTargetTemperature(requested);
+        ESP_LOGD("control", "DRY received single target: high=%.1f (low now %.1f)", this->getTargetTemperatureHigh(), this->getTargetTemperatureLow());
     }
 }
 
@@ -169,23 +169,36 @@ bool CN105Climate::processTemperatureChange(const esphome::climate::ClimateCall&
         ESP_LOGD("control", "A temperature setpoint value has been provided...");
     }
 
+    float temp_low = NAN;
+    float temp_high = NAN;
+    float temp_single = NAN;
+    if (call.get_target_temperature_low().has_value()) {
+        temp_low = this->fahrenheitSupport_.normalizeUiTemperatureToHeatpumpTemperature(*call.get_target_temperature_low());
+    }
+    if (call.get_target_temperature_high().has_value()) {
+        temp_high = this->fahrenheitSupport_.normalizeUiTemperatureToHeatpumpTemperature(*call.get_target_temperature_high());
+    }
+    if (call.get_target_temperature().has_value()) {
+        temp_single = this->fahrenheitSupport_.normalizeUiTemperatureToHeatpumpTemperature(*call.get_target_temperature());
+    }
+
     if (this->traits_.has_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE)) {
         ESP_LOGD("control", "Processing with dual setpoint support...");
         if (call.get_target_temperature_low().has_value() && call.get_target_temperature_high().has_value()) {
-            this->handleDualSetpointBoth(*call.get_target_temperature_low(), *call.get_target_temperature_high());
+            this->handleDualSetpointBoth(temp_low, temp_high);
         } else if (call.get_target_temperature_low().has_value()) {
-            this->handleDualSetpointLowOnly(*call.get_target_temperature_low());
+            this->handleDualSetpointLowOnly(temp_low);
         } else if (call.get_target_temperature_high().has_value()) {
-            this->handleDualSetpointHighOnly(*call.get_target_temperature_high());
+            this->handleDualSetpointHighOnly(temp_high);
         } else if (call.get_target_temperature().has_value() &&
             (this->mode == climate::CLIMATE_MODE_AUTO || this->mode == climate::CLIMATE_MODE_DRY)) {
-            this->handleSingleTargetInAutoOrDry(*call.get_target_temperature());
+            this->handleSingleTargetInAutoOrDry(temp_single);
         }
     } else {
         ESP_LOGD("control", "Processing without dual setpoint support...");
         if (call.get_target_temperature().has_value()) {
-            this->target_temperature = *call.get_target_temperature();
-            ESP_LOGI("control", "Setting heatpump setpoint : %.1f", this->target_temperature);
+            this->setTargetTemperature(temp_single);
+            ESP_LOGI("control", "Setting heatpump setpoint : %.1f", this->getTargetTemperature());
         }
     }
 
@@ -349,48 +362,48 @@ void CN105Climate::controlTemperature() {
 
             if (this->traits_.has_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE)) {
                 if ((!std::isnan(currentSettings.temperature)) && (currentSettings.temperature > 0)) {
-                    this->target_temperature_low = currentSettings.temperature - 2.0f;
-                    this->target_temperature_high = currentSettings.temperature + 2.0f;
+                    this->setTargetTemperatureLow(currentSettings.temperature - 2.0f);
+                    this->setTargetTemperatureHigh(currentSettings.temperature + 2.0f);
                     ESP_LOGI("control", "Initializing AUTO mode temps from current PAC temp: %.1f -> [%.1f - %.1f]",
-                        currentSettings.temperature, this->target_temperature_low, this->target_temperature_high);
+                        currentSettings.temperature, this->getTargetTemperatureLow(), this->getTargetTemperatureHigh());
                     //this->publish_state();
                 }
                 setting = currentSettings.temperature;
                 ESP_LOGD("control", "AUTO mode : getting median temperature from current PAC temp: %.1f", setting);
             } else {
-                setting = this->target_temperature;
+                setting = this->getTargetTemperature();
             }
 
             break;
 
         case climate::CLIMATE_MODE_HEAT:
             // Mode HEAT : using low target temperature
-            setting = this->target_temperature_low;
-            ESP_LOGD("control", "HEAT mode : getting temperature low:%1.f", this->target_temperature_low);
+            setting = this->getTargetTemperatureLow();
+            ESP_LOGD("control", "HEAT mode : getting temperature low:%1.f", this->getTargetTemperatureLow());
             break;
         case climate::CLIMATE_MODE_COOL:
             // Mode COOL : using high target temperature
-            setting = this->target_temperature_high;
-            ESP_LOGD("control", "COOL mode : getting temperature high:%1.f", this->target_temperature_high);
+            setting = this->getTargetTemperatureHigh();
+            ESP_LOGD("control", "COOL mode : getting temperature high:%1.f", this->getTargetTemperatureHigh());
             break;
         case climate::CLIMATE_MODE_DRY:
             // Mode DRY : using high target temperature
-            setting = this->target_temperature_high;
-            ESP_LOGD("control", "COOL mode : getting temperature high:%1.f", this->target_temperature_high);
+            setting = this->getTargetTemperatureHigh();
+            ESP_LOGD("control", "COOL mode : getting temperature high:%1.f", this->getTargetTemperatureHigh());
             break;
         default:
             // Other modes : use median temperature
             if (this->traits_.has_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE)) {
-                setting = (this->target_temperature_low + this->target_temperature_high) / 2.0f;
+                setting = (this->getTargetTemperatureLow() + this->getTargetTemperatureHigh()) / 2.0f;
             } else {
-                setting = this->target_temperature;
+                setting = this->getTargetTemperature();
             }
             ESP_LOGD("control", "DEFAULT mode : getting temperature median:%1.f", setting);
             break;
         }
     } else {
         // Single setpoint : utiliser target_temperature
-        setting = this->target_temperature;
+        setting = this->getTargetTemperature();
     }
 
     setting = this->calculateTemperatureSetting(setting);
@@ -508,16 +521,16 @@ void CN105Climate::updateAction() {
         if (this->traits().supports_mode(climate::CLIMATE_MODE_HEAT) &&
             this->traits().supports_mode(climate::CLIMATE_MODE_COOL)) {
             // If the unit supports both heating and cooling
-            if (this->current_temperature >= this->target_temperature_high) {
+            if (this->getCurrentTemperature() >= this->getTargetTemperatureHigh()) {
                 this->setActionIfOperatingTo(climate::CLIMATE_ACTION_COOLING);
-            } else if (this->current_temperature <= this->target_temperature_low) {
+            } else if (this->getCurrentTemperature() <= this->getTargetTemperatureLow()) {
                 this->setActionIfOperatingTo(climate::CLIMATE_ACTION_HEATING);
             } else {
                 this->setActionIfOperatingTo(climate::CLIMATE_ACTION_IDLE);
             }
         } else if (this->traits().supports_mode(climate::CLIMATE_MODE_COOL)) {
             // If the unit only supports cooling
-            if (this->current_temperature < this->target_temperature_high) {
+            if (this->getCurrentTemperature() < this->getTargetTemperatureHigh()) {
                 // If the temperature meets or exceeds the target, switch to fan-only mode
                 this->setActionIfOperatingTo(climate::CLIMATE_ACTION_IDLE);
             } else {
@@ -526,7 +539,7 @@ void CN105Climate::updateAction() {
             }
         } else if (this->traits().supports_mode(climate::CLIMATE_MODE_HEAT)) {
             // If the unit only supports heating
-            if (this->current_temperature >= this->target_temperature_low) {
+            if (this->getCurrentTemperature() >= this->getTargetTemperatureLow()) {
                 // If the temperature meets or exceeds the target, switch to fan-only mode
                 this->setActionIfOperatingTo(climate::CLIMATE_ACTION_IDLE);
             } else {
@@ -631,10 +644,6 @@ void CN105Climate::set_remote_temperature(float setting) {
         return;
     }
 
-    if (use_fahrenheit_support_mode_) {
-        setting = this->fahrenheitSupport_.normalizeCelsiusForConversionFromFahrenheit(setting);
-    }
-
     // Toujours renvoyer la température distante lorsqu’un nouvel échantillon arrive,
     // même si la valeur n’a pas changé, afin d’éviter que l’unité Mitsubishi
     // ne repasse sur la sonde interne faute de mise à jour régulière (#474).
@@ -642,4 +651,3 @@ void CN105Climate::set_remote_temperature(float setting) {
     this->shouldSendExternalTemperature_ = true;
     ESP_LOGD(LOG_REMOTE_TEMP, "setting remote temperature to %f", this->remoteTemperature_);
 }
-

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -71,7 +71,6 @@ namespace esphome {
         binary_sensor::BinarySensor* iSee_sensor_ = nullptr;
         text_sensor::TextSensor* stage_sensor_{ nullptr }; // to save ref if needed
         bool use_stage_for_operating_status_{ false };
-        bool use_fahrenheit_support_mode_ = false;
         FahrenheitSupport fahrenheitSupport_;
         text_sensor::TextSensor* Functions_sensor_ = nullptr;
         FunctionsButton* Functions_get_button_ = nullptr;
@@ -154,6 +153,7 @@ namespace esphome {
         void set_remote_temperature(float);
         void sendRemoteTemperature();
         void sendWantedRunStates();
+        float getDeadbandAdjustedTemperature(float remoteTemperature);
 
         void set_remote_temp_timeout(uint32_t timeout);
 
@@ -175,6 +175,14 @@ namespace esphome {
         void controlTemperature();
         float calculateTemperatureSetting(float setting);
         float getTargetTemperatureInCurrentMode();
+        float getTargetTemperature();
+        float getTargetTemperatureLow();
+        float getTargetTemperatureHigh();
+        float getCurrentTemperature();
+        void setTargetTemperature(float temperature);
+        void setTargetTemperatureLow(float temperature);
+        void setTargetTemperatureHigh(float temperature);
+        void setCurrentTemperature(float temperature);
 
         void controlFan();
         void controlSwing();

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -226,7 +226,6 @@ void CN105Climate::set_hp_uptime_connection_sensor(uptime::HpUpTimeConnectionSen
 }
 
 void CN105Climate::set_use_fahrenheit_support_mode(bool value) {
-    this->use_fahrenheit_support_mode_ = value;
     this->fahrenheitSupport_.setUseFahrenheitSupportMode(value);
     ESP_LOGI(TAG, "Fahrenheit compatibility mode enabled: %s", value ? "true" : "false");
 }

--- a/components/cn105/localization.h
+++ b/components/cn105/localization.h
@@ -10,8 +10,8 @@ namespace esphome {
                 use_fahrenheit_support_mode_ = value;
             }
 
-            float normalizeCelsiusForConversionToFahrenheit(const float c) {
-                if (!use_fahrenheit_support_mode_) {
+            float normalizeHeatpumpTemperatureToUiTemperature(const float c) {
+                if (!use_fahrenheit_support_mode_ || c == NAN) {
                     return c; // If not in Fahrenheit support mode, return the Celsius value as is.
                 }
 
@@ -35,10 +35,11 @@ namespace esphome {
                 return (fahrenheitResult - 32.0f) / 1.8f;
             }
 
-            float normalizeCelsiusForConversionFromFahrenheit(const float c) {
-                if (!use_fahrenheit_support_mode_) {
+            float normalizeUiTemperatureToHeatpumpTemperature(const float c) {
+                if (!use_fahrenheit_support_mode_ || c == NAN) {
                     return c; // If not in Fahrenheit support mode, return the Celsius value as is.
                 }
+
 
                 float fahrenheitInput = (c * 1.8f) + 32.0f;
 
@@ -62,7 +63,7 @@ namespace esphome {
 
         private:
             bool use_fahrenheit_support_mode_ = false;
-            
+
             // Given a temperature in Celsius that was converted from Fahrenheit, converts
             // it to the Celsius value (at half-degree precision) that matches what
             // Mitsubishi thermostats would have converted the Fahrenheit value to. For


### PR DESCRIPTION
This change adds a clear separation of concerns between the Home Asisstant UI and the heatpump. For a value to pass between the two, it must be normalized in either direction.

The target_temperature/target_temperature_low/target_temperature_high/current_temperature have all been given getters and setters which handle the normalization to/from UI safe temperatures. As long as we call those methods instead of setting these member variables directly, fahrenheit support will continue to work and be less confusing than what it is today.

For set_remote_temperature I removed the fahrenheit normalization. Personally I use MQTT to push external temperatures already in degrees C, and with them getting normalized is providing inaccurate external temperatures to the heatpump. I don't know if Home Assistant are screwing up conversions here, but I'd be happy to add a second remote_temperature_fahrenheit_support flag if my assumptions are wrong.