### PR TITLE
feat: Release HEAT_COOL mode and Hybrid Component

### DIFF
--- a/custom_components/mitsubishi_hybrid/__init__.py
+++ b/custom_components/mitsubishi_hybrid/__init__.py
@@ -1,8 +1,28 @@
+import logging
 from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "mitsubishi_hybrid"
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Mitsubishi Hybrid component."""
+    """Set up the Mitsubishi Hybrid Climate component via YAML (legacy)."""
+    # Return true to allow platform setup (which is handled in climate.py)
+    # This allows keeping the old configuration method working if needed,
+    # or we can fully deprecate it. For now, we return True.
     return True
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Mitsubishi Hybrid Climate from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    
+    # Forward the setup to the climate platform
+    await hass.config_entries.async_forward_entry_setups(entry, ["climate"])
+    
+    return True
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, ["climate"])

--- a/custom_components/mitsubishi_hybrid/climate.py
+++ b/custom_components/mitsubishi_hybrid/climate.py
@@ -39,7 +39,7 @@ async def async_setup_platform(
     async_add_entities: Any,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the Mitsubishi Hybrid Climate platform."""
+    """Set up the Mitsubishi Hybrid Climate platform via YAML."""
     source_entity_id = config[CONF_SOURCE_ENTITY]
     name = config.get(CONF_NAME)
 
@@ -48,17 +48,33 @@ async def async_setup_platform(
         True,
     )
 
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigType,
+    async_add_entities: Any,
+) -> None:
+    """Set up the Mitsubishi Hybrid Climate platform via Config Flow."""
+    source_entity_id = entry.data[CONF_SOURCE_ENTITY]
+    name = entry.data.get(CONF_NAME)
+
+    async_add_entities(
+        [MitsubishiHybridClimate(hass, name, source_entity_id, entry.entry_id)],
+        True,
+    )
+
 
 class MitsubishiHybridClimate(ClimateEntity):
     """Representation of a Mitsubishi Hybrid Climate device."""
 
-    def __init__(self, hass: HomeAssistant, name: str, source_entity_id: str) -> None:
+    def __init__(self, hass: HomeAssistant, name: str, source_entity_id: str, unique_id: str = None) -> None:
         """Initialize the climate device."""
         self._hass = hass
         self._name = name or source_entity_id
         self._source_entity_id = source_entity_id
         self._source_state = None
         self._attr_should_poll = False
+        self._attr_unique_id = unique_id or f"{source_entity_id}_hybrid"
+
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -86,7 +102,7 @@ class MitsubishiHybridClimate(ClimateEntity):
     @property
     def unique_id(self) -> str:
         """Return the unique ID of the entity."""
-        return f"{self._source_entity_id}_hybrid"
+        return self._attr_unique_id
 
     @property
     def available(self) -> bool:

--- a/custom_components/mitsubishi_hybrid/config_flow.py
+++ b/custom_components/mitsubishi_hybrid/config_flow.py
@@ -1,0 +1,43 @@
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.const import CONF_NAME, CONF_SOURCE
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+
+from . import DOMAIN
+
+class MitsubishiHybridConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Mitsubishi Hybrid Climate."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+
+        if user_input is not None:
+            # Validate input
+            await self.async_set_unique_id(f"{user_input[CONF_SOURCE]}_hybrid")
+            self._abort_if_unique_id_configured()
+
+            return self.async_create_entry(
+                title=user_input.get(CONF_NAME, user_input[CONF_SOURCE]),
+                data=user_input
+            )
+
+        # Get list of climate entities to offer in dropdown
+        climate_entities = [
+            ent.entity_id for ent in self.hass.states.async_all(CLIMATE_DOMAIN)
+        ]
+
+        data_schema = vol.Schema({
+            vol.Required(CONF_SOURCE): vol.In(climate_entities),
+            vol.Optional(CONF_NAME): str,
+        })
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=data_schema,
+            errors=errors
+        )

--- a/custom_components/mitsubishi_hybrid/manifest.json
+++ b/custom_components/mitsubishi_hybrid/manifest.json
@@ -7,6 +7,7 @@
     "codeowners": [
         "@echavet"
     ],
+    "config_flow": true,
     "requirements": [],
     "integration_type": "device",
     "iot_class": "local_polling"

--- a/custom_components/mitsubishi_hybrid/strings.json
+++ b/custom_components/mitsubishi_hybrid/strings.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Add Mitsubishi Hybrid Climate",
+        "description": "Create a hybrid entity (Dual/Single setpoint wrapper)",
+        "data": {
+          "source": "Source Entity (ESPHome Climate)",
+          "name": "Name for the new Hybrid Entity"
+        }
+      }
+    },
+    "error": {
+      "already_configured": "This entity is already configured."
+    },
+    "abort": {
+      "already_configured": "This entity is already configured."
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces a comprehensive solution for supporting dual-setpoint `HEAT_COOL` mode while preserving the native Mitsubishi `AUTO` mode behavior.

### Why this approach?

Standard mapping of `AUTO` to `HEAT_COOL` (as proposed in previous discussions) replaces the native `AUTO` mode, which is problematic for users relying on the hardware's internal single-setpoint logic.

**This implementation achieves the best of both worlds:**
1.  **Preserves Native AUTO:** The `AUTO` mode remains mapped to a single setpoint, sending the standard command to the hardware.
2.  **Adds Logical HEAT_COOL:** A new `HEAT_COOL` mode is introduced. In this mode:
    *   ESPHome accepts a dual setpoint (`low` / `high`) from Home Assistant.
    *   It applies a deadband logic internally.
    *   It sends the appropriate commands to the hardware (using the hardware's `AUTO` mode but calculating the optimal setpoint based on the dual inputs).

### The "Global Trait" Issue & Solution

ESPHome currently defines the `supports_two_point_target_temperature` trait globally for the component, not per mode.
*   **Consequence:** Enabling `HEAT_COOL` forces the "Dual Setpoint" UI (2 sliders) on **ALL** modes (Heat, Cool, Auto) in Home Assistant. This degrades the UX for single-setpoint modes.
*   **Solution:** Included is a **Home Assistant Custom Component** (`mitsubishi_hybrid`) which solves this UI glitch.

### Hybrid Component Features (UI Configurable)
The `mitsubishi_hybrid` component acts as a **"Thin Wrapper"** around the ESPHome entity.
1.  **Dynamic Feature Masking:** It dynamically recalculates its `supported_features` property based on the current HVAC Mode.
    *   In `HEAT_COOL` -> Reports `TARGET_TEMPERATURE_RANGE` (Dual sliders).
    *   In `AUTO/HEAT` -> Reports `TARGET_TEMPERATURE` (Single slider).
2.  **Config Flow Support:** Fully configurable via Home Assistant UI.

### How to use

1.  **Flash this firmware**:
    *   **CRITICAL**: You must set `dual_setpoint: true` in your YAML configuration under the `climate` component options.
2.  **Install the wrapper**: Copy `custom_components/mitsubishi_hybrid` to your HA configuration (or add via HACS).
3.  **Configure in HA**: Use the "Add Integration" UI to search for "Mitsubishi Hybrid".

### Technical Changes
*   **climate.py**: Added `HEAT_COOL` to supported modes.
*   **climateControls.cpp**: Implemented deadband logic and dual setpoint handling.
*   **Custom Component**: Added full implementation of `mitsubishi_hybrid` with Config Flow.

Closes #525

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a Home Assistant custom component `mitsubishi_hybrid` that wraps an existing climate entity and dynamically exposes single or dual setpoint controls based on `hvac_mode`.
> 
> - New integration files: `__init__.py`, `climate.py`, `config_flow.py`, `manifest.json`, and `strings.json` with `config_flow: true`
> - `async_setup_entry`/`async_unload_entry` implemented to forward setup to the `climate` platform; legacy YAML setup still supported
> - `climate.py`: adds `async_setup_entry`, unique IDs, state tracking, and proxies service calls (`set_hvac_mode`, `set_temperature`, `set_fan_mode`, `set_swing_mode`) to the source entity
> - Dynamic `supported_features`: reports `TARGET_TEMPERATURE_RANGE` in `HEAT_COOL`, otherwise `TARGET_TEMPERATURE`
> - Temperature getters/setters handle conversions between single target and `target_temp_low/high` for modes (HEAT/COOL/DRY/AUTO)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d05405c53cc93340e510f07cd22408b205b3a2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->