### PR TITLE
Fix empty proxy climate card

### DIFF
--- a/custom_components/mitsubishi_climate_proxy/climate.py
+++ b/custom_components/mitsubishi_climate_proxy/climate.py
@@ -133,8 +133,8 @@ class MitsubishiHybridClimate(ClimateEntity):
         features = source_features & ~ClimateEntityFeature.TARGET_TEMPERATURE
         features = features & ~ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
 
-        # Dynamically add the flag based on current mode
-        if self.hvac_mode == HVACMode.HEAT_COOL:
+        # Dynamically add the flag based on available modes
+        if HVACMode.HEAT_COOL in self.hvac_modes:
             features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         else:
             features |= ClimateEntityFeature.TARGET_TEMPERATURE


### PR DESCRIPTION
This change will fix the empty proxy climate card when the Mode is `Off`.

With this update the proxy climate card will always show the single setpoint or the dual setpoints in any mode.

My system with this update shows this in mode = off:
<img width="496" height="391" alt="image" src="https://github.com/user-attachments/assets/3ae42291-823f-4608-96b6-b344b9553814" />
