### PR TITLE
v1.6.5 - Fix proxy climate card regression

### DIFF
--- a/custom_components/mitsubishi_climate_proxy/climate.py
+++ b/custom_components/mitsubishi_climate_proxy/climate.py
@@ -133,8 +133,10 @@ class MitsubishiHybridClimate(ClimateEntity):
         features = source_features & ~ClimateEntityFeature.TARGET_TEMPERATURE
         features = features & ~ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
 
-        # Dynamically add the flag based on available modes
-        if HVACMode.HEAT_COOL in self.hvac_modes:
+        # Dynamically add the flag based on current mode
+        # Use RANGE if we are in HEAT_COOL mode, OR if we are in OFF mode and the device supports HEAT_COOL
+        # (This ensures OFF mode shows dual setpoints instead of being empty, as OFF typically lacks a single 'temperature' attribute on dual-sp entities)
+        if self.hvac_mode == HVACMode.HEAT_COOL or (self.hvac_mode == HVACMode.OFF and HVACMode.HEAT_COOL in self.hvac_modes):
             features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         else:
             features |= ClimateEntityFeature.TARGET_TEMPERATURE

--- a/custom_components/mitsubishi_climate_proxy/manifest.json
+++ b/custom_components/mitsubishi_climate_proxy/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "mitsubishi_climate_proxy",
     "name": "Mitsubishi Climate Proxy",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "documentation": "https://github.com/echavet/MitsubishiCN105ESPHome",
     "dependencies": [],
     "codeowners": [


### PR DESCRIPTION
Fixes issue where single setpoint mode was not active in non-HEAT_COOL modes, while preserving fix for empty card in OFF mode.