### PR TITLE
v1.6.6 - Fix regressions: Proxy dual logic & COOL/DRY NaN temp

### DIFF
--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -393,21 +393,20 @@ def to_code(config):
 
         # Set dual setpoint support via YAML (default: False if missing)
         # Note: this enables global dual setpoint support in HA.
-        # Ideally, we would want to enable it per mode, but ESPHome traits are global.
-        # With HA 2025.10+, HA dynamically masks the 2nd slider if the mode doesn't require it
-        # BUT the component must declare it.
         yaml_dual = supports.get(CONF_DUAL_SETPOINT, False)
-
-        # Use the C++ constant directly via RawExpression to avoid fetching it from Python side
+        
+        # Use the C++ constant directly via RawExpression
         dual_flag = cg.RawExpression(
             "climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE"
         )
+
         if yaml_dual:
-            # Enable dual setpoint flag via feature flags API (replaces deprecated call)
-            cg.add(traits.add_feature_flags(dual_flag))
-        else:
-            # Ensure the flag is disabled if YAML option is False
-            cg.add(traits.clear_feature_flags(dual_flag))
+             cg.add(traits.add_feature_flags(dual_flag))
+        
+        # Note: If yaml_dual is False, we simply do NOT add the dual_flag.
+        # ESPHome's default behavior for modes like COOL/HEAT is to enable single-point target temperature.
+        # We don't need to explicitly force single-point or clear the dual flag (it's off by default).
+        
         for fan_mode_str in supports.get(CONF_FAN_MODE, DEFAULT_FAN_MODES):
             if fan_mode_str in climate.CLIMATE_FAN_MODES:
                 cg.add(

--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -405,18 +405,30 @@ void CN105Climate::controlTemperature() {
 
         case climate::CLIMATE_MODE_HEAT:
             // Mode HEAT : using low target temperature
-            setting = this->getTargetTemperatureLow();
-            ESP_LOGD("control", "HEAT mode : getting temperature low:%1.f", this->getTargetTemperatureLow());
+            if (this->traits_.has_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE)) {
+                setting = this->getTargetTemperatureLow();
+            } else {
+                setting = this->getTargetTemperature();
+            }
+            ESP_LOGD("control", "HEAT mode : getting temperature (low/target): %1.f", setting);
             break;
         case climate::CLIMATE_MODE_COOL:
             // Mode COOL : using high target temperature
-            setting = this->getTargetTemperatureHigh();
-            ESP_LOGD("control", "COOL mode : getting temperature high:%1.f", this->getTargetTemperatureHigh());
+            if (this->traits_.has_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE)) {
+                setting = this->getTargetTemperatureHigh();
+            } else {
+                setting = this->getTargetTemperature();
+            }
+            ESP_LOGD("control", "COOL mode : getting temperature (high/target): %1.f", setting);
             break;
         case climate::CLIMATE_MODE_DRY:
             // Mode DRY : using high target temperature
-            setting = this->getTargetTemperatureHigh();
-            ESP_LOGD("control", "COOL mode : getting temperature high:%1.f", this->getTargetTemperatureHigh());
+            if (this->traits_.has_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE)) {
+                setting = this->getTargetTemperatureHigh();
+            } else {
+                setting = this->getTargetTemperature();
+            }
+            ESP_LOGD("control", "DRY mode : getting temperature (high/target): %1.f", setting);
             break;
         default:
             // Other modes : use median temperature

--- a/custom_components/mitsubishi_climate_proxy/manifest.json
+++ b/custom_components/mitsubishi_climate_proxy/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "mitsubishi_climate_proxy",
     "name": "Mitsubishi Climate Proxy",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "documentation": "https://github.com/echavet/MitsubishiCN105ESPHome",
     "dependencies": [],
     "codeowners": [


### PR DESCRIPTION
Fixes two regressions:
1. Proxy component: restore correct single/dual setpoint logic based on device capabilities (fix for non-dual units).
2. ESPHome component: fix NaN target temperature sent in COOL/DRY modes for single-setpoint units (restores missing slider).