### PR TITLE
Fix build with 2016.1.0: StringRef to char*

### DIFF
--- a/components/cn105/hardware_setting_select.cpp
+++ b/components/cn105/hardware_setting_select.cpp
@@ -32,7 +32,7 @@ namespace esphome {
         const char *cur_opt = nullptr;
         
         #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
-            cur_opt = this->current_option(); 
+            cur_opt = this->current_option().c_str();
             changed = (cur_opt == nullptr) || (std::strcmp(cur_opt, new_state.c_str()) != 0);
         #else
             cur_opt = this->state.c_str();

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -677,13 +677,13 @@ void CN105Climate::checkWideVaneSettings(heatpumpSettings& settings, bool update
 }
 void CN105Climate::updateExtraSelectComponents(heatpumpSettings& settings) {
     if (this->vertical_vane_select_ != nullptr) {
-        if (this->hasChanged(this->vertical_vane_select_->current_option(), settings.vane, "select vane")) {
+        if (this->hasChanged(this->vertical_vane_select_->current_option().c_str(), settings.vane, "select vane")) {
             ESP_LOGI(TAG, "vane setting (extra select component) changed");
             this->vertical_vane_select_->publish_state(settings.vane);
         }
     }
     if (this->horizontal_vane_select_ != nullptr) {
-        if (this->hasChanged(this->horizontal_vane_select_->current_option(), settings.wideVane, "select wideVane")) {
+        if (this->hasChanged(this->horizontal_vane_select_->current_option().c_str(), settings.wideVane, "select wideVane")) {
             ESP_LOGI(TAG, "widevane setting (extra select component) changed");
             this->horizontal_vane_select_->publish_state(settings.wideVane);
         }

--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -310,7 +310,7 @@ void CN105Climate::publishWantedRunStatesStateToHA() {
         if (this->wantedRunStates.airflow_control == nullptr) {
             this->wantedRunStates.airflow_control = this->currentRunStates.airflow_control;
         }
-        if (this->hasChanged(this->airflow_control_select_->current_option(), this->wantedRunStates.airflow_control, "select airflow control")) {
+        if (this->hasChanged(this->airflow_control_select_->current_option().c_str(), this->wantedRunStates.airflow_control, "select airflow control")) {
             ESP_LOGI(TAG, "airflow control setting changed");
             this->airflow_control_select_->publish_state(wantedRunStates.airflow_control);
         }


### PR DESCRIPTION
Select::current_option() returns a StringRef now.