### PR TITLE
ci: update ESPHome version to latest stable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        version: [2025.11.0]
+        version: [stable]
         variant: [examples/root-configs/esp32-test, examples/root-configs/hp-debug]
     container:
       image: ghcr.io/esphome/esphome:${{ matrix.version }}


### PR DESCRIPTION
Rather than updating the version every time, use the label `stable` to refer to latest version released.
In this case this should point to 2026.1.4