### PR TITLE
Convert BTU/h to Watts

### DIFF
--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -121,6 +121,8 @@ namespace esphome {
         // sensor to monitor heatpump connection time
         cn105::HpUpTimeConnectionSensor* hp_uptime_connection_sensor_ = nullptr;
 
+        float convert_input_power_to_W(float raw_input_power);
+        float convert_energy_usage_to_kWh(float raw_energy_usage);
         float get_compressor_frequency();
         float get_input_power();
         float get_kwh();

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -338,17 +338,12 @@ void CN105Climate::getOperatingAndCompressorFreqFromResponsePacket() {
     ESP_LOGD("Decoder", "[0x06 is status]");
     //this->last_received_packet_sensor->publish_state("0x62-> 0x06: Data -> Heatpump Status");
 
-    // We need a factor to convert BTU/h to Watts
-    // The definition is as follows 1000 BTU/h = (1 055 055.582 62 J/3600s) ~= 293W 
-    // The factor BTU/h -> W is approx. 3.412
-    static constexpr float conv_factor = (1000*3600)/1055055.58262;
-
     // reset counter (because a reply indicates it is connected)
     this->nonResponseCounter = 0;
     receivedStatus.operating = data[4];
     receivedStatus.compressorFrequency = data[3];
-    receivedStatus.inputPower = float((data[5] << 8) | data[6]) * conv_factor;
-    receivedStatus.kWh = float((data[7] << 8) | data[8]) / 10;
+    receivedStatus.inputPower = convert_input_power_to_W(float((data[5] << 8) | data[6]));
+    receivedStatus.kWh = convert_energy_usage_to_kWh(float((data[7] << 8) | data[8]));
 
     // no change with this packet to roomTemperature
     receivedStatus.roomTemperature = currentStatus.roomTemperature;

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -53,6 +53,29 @@ float CN105Climate::calculateTemperatureSetting(float setting) {
 }
 
 /**
+ * Convert raw input power value to Watts
+ * It seems that the value is provided by the unit in BTU/s
+ * 
+ * The Conversion is based on the definitions:
+ * 1 BTU = 1055.05585262 J
+ * 1 W = 1 J / s
+ */
+
+float CN105Climate::convert_input_power_to_W(float raw_input_power) {
+    static constexpr float conv_factor = 3600.0f / 1055.05558262f;
+    return raw_input_power * conv_factor;
+}
+
+/**
+ * Convert the raw energy usage value to kWh
+ * It seems that the value is provided by the unit in kBTU
+ */
+float CN105Climate::convert_energy_usage_to_kWh(float raw_energy_usage) {
+    static constexpr float conv_factor = 1055.05585262f/3600000.0f;
+    return 1000.0f * raw_energy_usage * conv_factor;
+}
+
+/**
  * This function updates the target temperatures from the settings.
  * It also calculates the temperature setting based on the mode and the temperature points.
  * It returns the temperature setting.


### PR DESCRIPTION
I did several experiments to verify the input power readings of my climate unit with readings by external equipment (Shelly 2 PM Plus in this case).
These experiments showed an almost static factor that was ~3.5
Considering the power usage of the outdoor unit fan and the indoor unit (max 27W) that could not yield such a huge difference, I figured out that my (and probably other ones as well) unit **provides the power values in BTU/h** that as a conversion factor ~3.421 which correlates with my observation very well.

To verify my change I put the unit into heating mode with a very high target temperature and now it's input power readings actually reached the 800 watts specified on the outdoor unit.

Did anyone else verify the power reading of his unit? Certainly most units report the value also in BTU/h if my theory is correct. 
The provided pull request converts the received value to Watts.

My Unit: (verified with two equal systems)
**Indoor:** `MSZ-LN35VG2W`
**Outdoor:** `MUZ-LN35VG2`

