### PR TITLE
fix: display remote sensor temp in HA climate entity when active

### DIFF
--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -10,7 +10,7 @@ void esphome::log_info_uint32(const char* tag, const char* msg, uint32_t value, 
 #else
     ESP_LOGI(tag, "%s %u %s", msg, (unsigned int)value, suffix);
 #endif
-}
+
 void esphome::log_debug_uint32(const char* tag, const char* msg, uint32_t value, const char* suffix) {
 #if __GNUC__ >= 11
     ESP_LOGD(tag, "%s %lu %s", msg, (unsigned long)value, suffix);
@@ -237,7 +237,12 @@ void CN105Climate::setTargetTemperatureHigh(float temperature) {
 }
 
 void CN105Climate::setCurrentTemperature(float temperature) {
-    this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(temperature);
+    // If a remote temperature sensor is active, display that value in HA instead of the HP internal sensor
+    if (this->remoteTemperature_ > 0) {
+        this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(this->remoteTemperature_);
+    } else {
+        this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(temperature);
+    }
 }
 
 void CN105Climate::sanitizeDualSetpoints() {


### PR DESCRIPTION
## Problem

When a remote temperature sensor is configured via `set_remote_temperature()`, the HA climate entity displays the heat pump's internal intake sensor temperature instead of the remote sensor value.

## Root Cause

`setCurrentTemperature()` in `utils.cpp` always assigns `this->current_temperature` from raw HP data, ignoring `remoteTemperature_` which was only used to send the override temp to the heat pump — not for HA display.

## Fix

Check `remoteTemperature_ > 0` before assigning `current_temperature`. When a remote sensor is active, use it for display instead of the HP intake reading. When `set_remote_temperature(0)` is called (timeout), falls back to HP sensor automatically.