### PR TITLE
Add state codes for MFZ units

### DIFF
--- a/components/cn105/cn105_types.h
+++ b/components/cn105/cn105_types.h
@@ -93,10 +93,35 @@ static const char* AIRFLOW_CONTROL_MAP[3] = { "EVEN", "INDIRECT", "DIRECT" };
 static const uint8_t STAGE[7] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
 static const char* STAGE_MAP[7] = { "IDLE", "LOW", "GENTLE", "MEDIUM", "MODERATE", "HIGH", "DIFFUSE" };
 
-static const uint8_t SUB_MODE[5] = { 0x00, 0x01, 0x02, 0x04, 0x08 };
-static const char* SUB_MODE_MAP[5] = { "NORMAL", "WARMUP", "DEFROST", "PREHEAT", "STANDBY" };
-static const uint8_t AUTO_SUB_MODE[4] = { 0x00, 0x01, 0x02, 0x03 };
-static const char* AUTO_SUB_MODE_MAP[4] = { "AUTO_OFF","AUTO_COOL", "AUTO_HEAT", "AUTO_LEADER" };
+// 0x10 = OFF state, observed on MFZ-KX09NL / MFZ-KJ18NA when the unit is
+// powered off (data[3] of the 0x09 packet). Confirmed by correlation with
+// 0x02 data[3] (power) = 0x00 across every powered-off cycle.
+static const uint8_t SUB_MODE[6] = { 0x00, 0x01, 0x02, 0x04, 0x08, 0x10 };
+static const char* SUB_MODE_MAP[6] = { "NORMAL", "WARMUP", "DEFROST", "PREHEAT", "STANDBY", "OFF" };
+
+// 0x40 / 0x41 / 0x43 added for newer MFZ units, where data[5] of the 0x09
+// packet is a bitfield rather than the older 0x00..0x03 enum:
+//   bit 0 (0x01) is set when AUTO climate mode is selected
+//   bit 1 (0x02) is set once the compressor has engaged in this AUTO
+//                session (i.e. the unit has identified the room needs
+//                active heating or cooling and acted on it). Sticky:
+//                stays set after the compressor cycles back off.
+//   bit 6 (0x40) is constantly set (purpose unknown, observed in every state
+//                including OFF, HEAT, COOL, DRY, FAN, AUTO across many cycles)
+//   bits 2..5  : unprobed
+// Observed states:
+//   0x40 AUTO_INACTIVE — AUTO mode not selected
+//   0x41 AUTO_IDLE     — AUTO selected, compressor not engaged
+//                        (e.g. room already at setpoint, no action needed)
+//   0x43 AUTO_ACTIVE   — AUTO selected, compressor has engaged at least
+//                        once in this session (sticky)
+// Note that 0x43 does NOT distinguish current cool-vs-heat direction; on these
+// units that has to be inferred from setpoint vs room temperature in 0x02.
+// These labels are distinct from the older AUTO_COOL/AUTO_HEAT/AUTO_LEADER
+// labels which appear to belong to a different protocol revision (older units
+// where this byte was a 4-state enum rather than a bitfield).
+static const uint8_t AUTO_SUB_MODE[7] = { 0x00, 0x01, 0x02, 0x03, 0x40, 0x41, 0x43 };
+static const char* AUTO_SUB_MODE_MAP[7] = { "AUTO_OFF", "AUTO_COOL", "AUTO_HEAT", "AUTO_LEADER", "AUTO_INACTIVE", "AUTO_IDLE", "AUTO_ACTIVE" };
 
 static const int TIMER_INCREMENT_MINUTES = 10;
 

--- a/components/cn105/cycle_management.cpp
+++ b/components/cn105/cycle_management.cpp
@@ -6,7 +6,7 @@ using namespace esphome;
 
 void cycleManagement::checkTimeout(unsigned int update_interval) {
     if (doesCycleTimeOut(update_interval)) {                          // does it last too long ?                    
-        ESP_LOGW(TAG, "Cycle timeout, reseting cycle...");
+        ESP_LOGW(TAG, "Cycle timeout, resetting cycle...");
         cycleEnded(true);
     }
 }

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -177,8 +177,8 @@ void CN105Climate::getPowerFromResponsePacket() {
 
     heatpumpSettings receivedSettings{};
     receivedSettings.stage = lookupByteMapValue(STAGE_MAP, STAGE, 7, data[4], "current stage for delivery");
-    receivedSettings.sub_mode = lookupByteMapValue(SUB_MODE_MAP, SUB_MODE, 5, data[3], "submode");
-    receivedSettings.auto_sub_mode = lookupByteMapValue(AUTO_SUB_MODE_MAP, AUTO_SUB_MODE, 4, data[5], "auto mode sub mode");
+    receivedSettings.sub_mode = lookupByteMapValue(SUB_MODE_MAP, SUB_MODE, 6, data[3], "submode");
+    receivedSettings.auto_sub_mode = lookupByteMapValue(AUTO_SUB_MODE_MAP, AUTO_SUB_MODE, 7, data[5], "auto mode sub mode");
 
     ESP_LOGD("Decoder", "[Stage : %s]", receivedSettings.stage);
     ESP_LOGD("Decoder", "[Sub Mode  : %s]", receivedSettings.sub_mode);


### PR DESCRIPTION
## Summary

Adds previously-unmapped values for `SUB_MODE` (`0x09` `data[3]`) and `AUTO_SUB_MODE` (`0x09` `data[5]`) observed on newer Mitsubishi MFZ floor-mount units, plus a typo fix.

Tested on **MFZ-KX09NL**; same log messages observed on **MFZ-KJ18NA**. Other unit families unaffected (the existing `0x00..0x03` enum entries remain intact).

The unmapped values cause repeated `[W][lookup:509]: ... value N not found, returning value at index 0` warnings every cycle, and make the corresponding text sensors silently misreport their state (e.g., reporting `NORMAL` while the unit is actually powered off, or `AUTO_OFF` while the unit is actively running in AUTO mode).

## Changes

- `cn105_types.h`: extend `SUB_MODE[]` from 5 to 6 entries and `AUTO_SUB_MODE[]` from 4 to 7 entries; document the bitfield interpretation of `data[5]` on these units.
- `hp_readings.cpp`: bump the length arguments to `lookupByteMapValue` so the new entries are reachable (`5 → 6` for sub-mode, `4 → 7` for auto sub-mode).
- `cycle_management.cpp`: fix `reseting` → `resetting` typo in a log line (drive-by fix).

## New labels

| Field | Value | Label |
|---|---|---|
| `SUB_MODE` | `0x10` | `OFF` |
| `AUTO_SUB_MODE` | `0x40` | `AUTO_INACTIVE` |
| `AUTO_SUB_MODE` | `0x41` | `AUTO_IDLE` |
| `AUTO_SUB_MODE` | `0x43` | `AUTO_ACTIVE` |

## Evidence and methodology

These labels were derived by capturing raw `0x09` packets across deliberate state transitions on the affected units, marking transition points in the log with `XXX <state>` sentinels, and diffing the byte values between marked regions.

### `SUB_MODE 0x10 = OFF`

Observed in three independent captures, in every cycle while the unit was powered off. Confirmed by correlation with `0x02 data[3]` (power byte): every cycle reporting `0x09 data[3] = 0x10` also reports `0x02 data[3] = 0x00` (power off), and vice versa.

Bit pattern is consistent with the existing single-bit enumeration of `SUB_MODE`: `0x00 / 0x01 / 0x02 / 0x04 / 0x08 / 0x10` are successive bit positions. `0x10` is the next position after the existing five entries.

A direct mid-cycle transition was also observed: when I pressed power-off, `0x09 data[3]` went `0x00 → 0x10` in the same poll cycle that `0x02 data[3]` went `0x01 → 0x00`.

### `AUTO_SUB_MODE` is a bitfield, not an enum, on these units

This is the more substantive finding. On older units (the provenance of the existing `0x00..0x03 / AUTO_OFF/COOL/HEAT/LEADER` entries), `data[5]` of the 0x09 packet is a 4-state enum. On newer MFZ units it appears to be a bitfield with the following structure:

| Bit | Mask | Meaning |
|---|---|---|
| 0 | `0x01` | AUTO climate mode is selected |
| 1 | `0x02` | The compressor has engaged at least once during this AUTO session (sticky — stays set after the compressor cycles back off) |
| 6 | `0x40` | Constantly set in every observed state and cycle (purpose unknown) |
| 2..5 | — | Unprobed; never observed set |

The three observed states are:

- **`0x40` = `AUTO_INACTIVE`** — bit 6 only. Reported in every non-AUTO mode (HEAT, COOL, DRY, FAN, OFF), in every captured cycle across multiple sessions. This is the "default" value of the byte when AUTO mode is not engaged.
- **`0x41` = `AUTO_IDLE`** — bits 6 + 0. Reported when AUTO mode is selected but the unit has not engaged the compressor in this session. Observed in two distinct sessions:
  - Engaged AUTO at room temperature setpoint, sat for ~20s. Compressor never engaged. `data[5]` = `0x41` for all 4 cycles.
  - Engaged AUTO at 72 °F and then 69 °F, sat for ~1 minute in each. Room was already near setpoint. Compressor never engaged at meaningful capacity (input power stayed at 4–5 W, the controller standby draw). `data[5]` = `0x41` for all captured cycles.
- **`0x43` = `AUTO_ACTIVE`** — bits 6 + 0 + 1. Reported when AUTO mode is selected and the compressor has engaged in this session.
  Observed in:
  - Engaged AUTO at 67 °F (well below room temp). Compressor engaged, input power 120–160 W. `data[5]` = `0x43` from the very first cycle. Changed setpoint to 77 °F; compressor stopped (`0x06 data[4]: 01 → 00`); `data[5]` **stayed at `0x43`** for the rest of the AUTO session, confirming bit 1 is sticky.
`0x43` does **not** distinguish current cool-vs-heat direction. Captures of AUTO mode in cooling and AUTO mode in heating both report identical `0x09` bytes; the only difference is the setpoint in `0x02`. On these units, the unit's chosen direction must be inferred from setpoint vs room temperature.

### Cross-checking the bit-1 hypothesis

The naive reading "`bit 1 = compressor running`" is **falsified** by HEAT mode captures: with the unit in HEAT mode and the compressor unambiguously running (300–450 W input power, the existing `OPERATING_STATUS:517: Action set by operating status (compressor running)` log line firing), `data[5]` is `0x40`, not `0x42`. Bit 1 is clear.

Therefore, bit 1 is **gated on bit 0** (AUTO mode): it represents "this AUTO session has engaged the compressor", not generic compressor activity. The labels `AUTO_INACTIVE / AUTO_IDLE / AUTO_ACTIVE` reflect this AUTO-mode-specific semantic.

Conclusion:
- AUTO + compressor never ran → `0x41`
- AUTO + compressor running → `0x43`
- AUTO + compressor stopped, formerly ran → `0x43`
- HEAT + compressor running → `0x40`

## Unknowns

These are flagged here so the labels can be revised by anyone with better information:

1. **What bit 6 represents.** It is constantly set on these units in every observed state. It may be a unit-class / firmware / feature flag, or a protocol-revision marker for the Mitsubishi cloud integration.  None of my captures provoke it to clear. If anyone knows what this bit means, let me know.
2. **Whether there is an `AUTO direction` bit elsewhere.** The protocol on these units does not appear to distinguish AUTO-cool from AUTO-heat in `0x09 data[5]`. It may be encoded in a byte we are not currently polling, or it may simply not be exposed.
3. **Whether `AUTO_LEADER` (existing `0x03` label) is correct on any unit.** I haven't touched it, but I have no way to verify it on these units since `data[5]` is no longer a 4-state enum here.

## Tradeoffs

- **Why label rather than rename the existing field.** Changing the field name (e.g. from `auto_sub_mode_sensor` to `auto_state_sensor`) would break existing YAML configs.  Adding new lookup entries is a strict superset of existing behavior on older units and is fully additive.
- **Why not split the byte into separate bit fields.** Same reason — that would change the API surface. A future PR could introduce a separate bit-decoded sensor without disturbing the existing one.
- **Why not contribute back to upstream-upstream (SwiCago).** SwiCago's `case 0x09` is empty (`// standby mode maybe?`); they have never decoded this packet. The `0x09` decoding in this repo is original work, so this PR is the natural place to extend it.

## Testing

- [x] Verified on MFZ-KX09NL same family) over multiple-cycle captures across HEAT, COOL, DRY, FAN, AUTO, OFF transitions.
- [x] Confirmed `[W][lookup:509]` warnings for `value 16` and `value 64` disappear after this change.
- [x] Confirmed `Sub mode` text sensor reports `OFF` when the unit is powered off and `NORMAL` / `PREHEAT` when it is running.
- [x] Confirmed `Auto mode` text sensor reports `AUTO_INACTIVE` in HEAT/COOL/DRY/FAN/OFF, `AUTO_IDLE` in AUTO with no compressor engagement, and `AUTO_ACTIVE` in AUTO with compressor engagement.
- [ ] CI build (will verify after the PR is open).
- [ ] No regression for older units: existing `0x00..0x03` mappings are untouched, so older-unit behavior is unchanged. I don't have any older units, so I'm reliant on review and others in the community!
