### PR TITLE
fix: Ignore iSee requirement for setting Horizontal Vane and Airflow Control

### DIFF
--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -160,9 +160,6 @@ const char* CN105Climate::getVaneSetting() {
 
 const char* CN105Climate::getWideVaneSetting() {
     if (this->wantedSettings.wideVane) {
-        if (strcmp(this->wantedSettings.wideVane, lookupByteMapValue(WIDEVANE_MAP, WIDEVANE, 8, 0x80 & 0x0F)) == 0 && !this->currentSettings.iSee) {
-            this->wantedSettings.wideVane = this->currentSettings.wideVane;
-        }
         return this->wantedSettings.wideVane;
     } else {
         return this->currentSettings.wideVane;


### PR DESCRIPTION
## Summary
Fixed iSee/AIRFLOW CONTROL deadlock on MSZ-LN18VG2V: Removed the iSee requirement that prevented setting Horizontal Vane to "AIRFLOW CONTROL" mode, which caused it to always revert.

## Problem
I was unable to set the Horizontal Vane to "AIRFLOW CONTROL" mode on my Mitsubishi MSZ-LN18VG2V heat pump. The value would always revert to the previous setting. This also prevented me from setting Airflow Control to DIRECT or INDIRECT modes.

The issue occurred because AIRFLOW CONTROL mode requires the iSee sensor (intelligent eye) to be enabled on the heat pump. However the heat pump automatically enables iSee when it receives an AIRFLOW CONTROL command and there seems no way to enable iSee independently.

## Root Cause
In [hp_writings.cpp](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), the [getWideVaneSetting()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) function contained a check that rejected any attempt to set the wideVane to AIRFLOW CONTROL mode if iSee was not already enabled:

```
if (strcmp(this->wantedSettings.wideVane, "AIRFLOW CONTROL") == 0 && !this->currentSettings.iSee) {
    this->wantedSettings.wideVane = this->currentSettings.wideVane;  // Revert
}
```

This created a deadlock: I couldn't command AIRFLOW CONTROL mode without iSee being enabled, but iSee would never be enabled because I couldn't send the command.
Only solution was to use the remote and change some settings that would enable the iSee sensor. And then I was able to change AIRFLOW CONTROL via ESPHome.

## Solution
Removed the iSee requirement from [getWideVaneSetting()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). The function now allows me to command AIRFLOW CONTROL mode regardless of the current iSee state. The heat pump seems to handles this correctly by automatically enabling iSee when required.
