### PR TITLE
feat: add error code sensor and remote temp source info

### DIFF
--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -54,7 +54,7 @@ from esphome.components.sensor import (
 )
 from esphome.core import CORE, coroutine
 
-# ... (AUTO_LOAD, DEPENDENCIES, toutes les constantes CONF_XXX_SENSOR, DEFAULT_MODES - identiques Ã  votre version) ...
+# ... (AUTO_LOAD, DEPENDENCIES, toutes les constantes CONF_XXX_SENSOR, DEFAULT_MODES - identiques ÃÂ  votre version) ...
 AUTO_LOAD = [
     "climate",
     "sensor",
@@ -139,7 +139,7 @@ CONF_DEBOUNCE_DELAY = "debounce_delay"
 CONF_CONNECTION_BOOTSTRAP_DELAY = "connection_bootstrap_delay"
 CONF_INSTALLER_MODE = "installer_mode"
 
-# DÃ©finitions des classes C++ (identiques Ã  votre version)
+# DÃÂ©finitions des classes C++ (identiques ÃÂ  votre version)
 VaneOrientationSelect = cg.global_ns.class_(
     "VaneOrientationSelect", select.Select, cg.Component
 )
@@ -184,7 +184,7 @@ HardwareSettingSelect = cg.global_ns.class_(
 )
 
 
-# --- Fonction d'aide pour rÃ©cupÃ©rer les pins TX/RX (identique Ã  votre version corrigÃ©e) ---
+# --- Fonction d'aide pour rÃÂ©cupÃÂ©rer les pins TX/RX (identique ÃÂ  votre version corrigÃÂ©e) ---
 def get_uart_pins_from_config(core_config, target_uart_id_str):
     tx_pin_num = -1
     rx_pin_num = -1
@@ -210,9 +210,9 @@ def get_uart_pins_from_config(core_config, target_uart_id_str):
 
 
 def get_uart_port_index(core_config, target_uart_id_str):
-    # ESPHome ne fournit pas directement l'index de contrÃ´leur; on l'infÃ¨re
-    # via l'ordre de dÃ©claration ou restons Ã  0 par dÃ©faut.
-    # On tente d'associer l'objet id() Ã  sa position.
+    # ESPHome ne fournit pas directement l'index de contrÃÂ´leur; on l'infÃÂ¨re
+    # via l'ordre de dÃÂ©claration ou restons ÃÂ  0 par dÃÂ©faut.
+    # On tente d'associer l'objet id() ÃÂ  sa position.
     idx = 0
     for i, uart_conf_item in enumerate(core_config.get("uart", [])):
         if str(uart_conf_item[CONF_ID]) == target_uart_id_str:
@@ -228,7 +228,7 @@ def get_uart_port_index(core_config, target_uart_id_str):
 
 # --- FIN de la fonction d'aide ---
 
-# SchÃ©mas pour les entitÃ©s optionnelles (identiques Ã  votre version)
+# SchÃÂ©mas pour les entitÃÂ©s optionnelles (identiques ÃÂ  votre version)
 SELECT_SCHEMA = select.select_schema(VaneOrientationSelect).extend(
     {cv.GenerateID(CONF_ID): cv.declare_id(VaneOrientationSelect)}
 )
@@ -286,6 +286,19 @@ AUTO_SUB_MODE_SENSOR_SCHEMA = text_sensor.text_sensor_schema(AutoSubModSensor).e
     {cv.GenerateID(CONF_ID): cv.declare_id(AutoSubModSensor)}
 )
 
+ERROR_CODE_SENSOR_SCHEMA = text_sensor.text_sensor_schema(ErrorCodeSensor).extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(ErrorCodeSensor)}
+)
+
+REMOTE_TEMP_SOURCE_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_REMOTE_TEMP_SOURCE_SENSOR_ID): cv.use_id(sensor.Sensor),
+        cv.Optional(CONF_REMOTE_TEMP_SOURCE_INFO): text_sensor.text_sensor_schema(RemoteTempSourceInfo).extend(
+            {cv.GenerateID(CONF_ID): cv.declare_id(RemoteTempSourceInfo)}
+        ),
+    }
+)
+
 REMOTE_TEMPERATURE_CONTROL_SENSOR_SCHEMA = binary_sensor.binary_sensor_schema(
     binary_sensor.BinarySensor,
     device_class="connectivity",
@@ -298,15 +311,15 @@ REMOTE_TEMPERATURE_CONTROL_SENSOR_SCHEMA = binary_sensor.binary_sensor_schema(
     }
 )
 
-# SchÃ©ma pour STAGE_SENSOR (qui est un text_sensor) AVEC la nouvelle sous-option
+# SchÃÂ©ma pour STAGE_SENSOR (qui est un text_sensor) AVEC la nouvelle sous-option
 STAGE_SENSOR_CONFIG_SCHEMA = text_sensor.text_sensor_schema(StageSensor).extend(
     {
-        # L'ID pour l'objet StageSensor C++ est gÃ©rÃ© par text_sensor.TEXT_SENSOR_SCHEMA (via CONF_ID)
+        # L'ID pour l'objet StageSensor C++ est gÃÂ©rÃÂ© par text_sensor.TEXT_SENSOR_SCHEMA (via CONF_ID)
         cv.Optional(CONF_USE_AS_OPERATING_FALLBACK, default=False): cv.boolean,
     }
 )
 
-# SchÃ©ma pour HP_UP_TIME_CONNECTION_SENSOR (identique Ã  votre version)
+# SchÃÂ©ma pour HP_UP_TIME_CONNECTION_SENSOR (identique ÃÂ  votre version)
 HP_UP_TIME_CONNECTION_SENSOR_SCHEMA = sensor.sensor_schema(
     HpUpTimeConnectionSensor,
     unit_of_measurement=UNIT_SECOND,
@@ -375,7 +388,7 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(
                 CONF_STAGE_SENSOR
-            ): STAGE_SENSOR_CONFIG_SCHEMA,  # ModifiÃ© pour le nouveau schÃ©ma
+            ): STAGE_SENSOR_CONFIG_SCHEMA,  # ModifiÃÂ© pour le nouveau schÃÂ©ma
             cv.Optional(CONF_SUB_MODE_SENSOR): SUB_MODE_SENSOR_SCHEMA,
             cv.Optional(CONF_AUTO_SUB_MODE_SENSOR): AUTO_SUB_MODE_SENSOR_SCHEMA,
             cv.Optional(CONF_ERROR_CODE_SENSOR): ERROR_CODE_SENSOR_SCHEMA,
@@ -463,7 +476,7 @@ def to_code(config):
         supports = config[CONF_SUPPORTS]
         traits = var.config_traits()
 
-        # Configurer les modes supportÃ©s
+        # Configurer les modes supportÃÂ©s
         supported_modes = supports.get(CONF_MODE, DEFAULT_CLIMATE_MODES)
         for mode_str in supported_modes:
             if mode_str == "OFF":
@@ -532,7 +545,7 @@ def to_code(config):
         )
     )
 
-    # --- Configuration des entitÃ©s optionnelles (style original) ---
+    # --- Configuration des entitÃÂ©s optionnelles (style original) ---
     if CONF_HORIZONTAL_SWING_SELECT in config:
         conf_item = config[CONF_HORIZONTAL_SWING_SELECT]
         # new_select s'occupe de l'enregistrement. options=[] est important.
@@ -557,15 +570,15 @@ def to_code(config):
         control_select_var = yield select.new_select(conf_item, options=[])
         cg.add(var.set_airflow_control_select(control_select_var))
 
-    # Pour les capteurs, text_sensors, etc., utiliser la mÃ©thode .new_... standard
+    # Pour les capteurs, text_sensors, etc., utiliser la mÃÂ©thode .new_... standard
     # Ces fonctions s'occupent de l'enregistrement du composant.
     if CONF_COMPRESSOR_FREQUENCY_SENSOR in config:
-        # conf = config[CONF_COMPRESSOR_FREQUENCY_SENSOR] # 'conf' est dÃ©jÃ  utilisÃ© comme argument de to_code
-        # conf["force_update"] = False # Ceci Ã©tait dans votre code original, le garder si pertinent
+        # conf = config[CONF_COMPRESSOR_FREQUENCY_SENSOR] # 'conf' est dÃÂ©jÃÂ  utilisÃÂ© comme argument de to_code
+        # conf["force_update"] = False # Ceci ÃÂ©tait dans votre code original, le garder si pertinent
         conf_item = config[CONF_COMPRESSOR_FREQUENCY_SENSOR]
         if (
             "force_update" not in conf_item
-        ):  # S'assurer de ne pas l'Ã©craser si l'user l'a mis
+        ):  # S'assurer de ne pas l'ÃÂ©craser si l'user l'a mis
             conf_item["force_update"] = False
         sensor_var = yield sensor.new_sensor(conf_item)
         cg.add(var.set_compressor_frequency_sensor(sensor_var))
@@ -657,7 +670,7 @@ def to_code(config):
     # --- TRAITEMENT POUR STAGE_SENSOR AVEC LA NOUVELLE OPTION ---
     if CONF_STAGE_SENSOR in config:
         conf_stage_dict = config[CONF_STAGE_SENSOR]
-        # new_text_sensor gÃ¨re la crÃ©ation et l'enregistrement de base du text_sensor
+        # new_text_sensor gÃÂ¨re la crÃÂ©ation et l'enregistrement de base du text_sensor
         stage_ts_var = yield text_sensor.new_text_sensor(conf_stage_dict)
         cg.add(var.set_stage_sensor(stage_ts_var))
 

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -54,7 +54,7 @@ from esphome.components.sensor import (
 )
 from esphome.core import CORE, coroutine
 
-# ... (AUTO_LOAD, DEPENDENCIES, toutes les constantes CONF_XXX_SENSOR, DEFAULT_MODES - identiques à votre version) ...
+# ... (AUTO_LOAD, DEPENDENCIES, toutes les constantes CONF_XXX_SENSOR, DEFAULT_MODES - identiques Ã  votre version) ...
 AUTO_LOAD = [
     "climate",
     "sensor",
@@ -95,6 +95,10 @@ CONF_FUNCTIONS_SET_VALUE = "functions_set_value"
 CONF_STAGE_SENSOR = "stage_sensor"
 CONF_SUB_MODE_SENSOR = "sub_mode_sensor"
 CONF_AUTO_SUB_MODE_SENSOR = "auto_sub_mode_sensor"
+CONF_ERROR_CODE_SENSOR = "error_code_sensor"
+CONF_REMOTE_TEMP_SOURCE = "remote_temperature_source"
+CONF_REMOTE_TEMP_SOURCE_SENSOR_ID = "sensor_id"
+CONF_REMOTE_TEMP_SOURCE_INFO = "remote_temperature_source_info"
 CONF_HP_UP_TIME_CONNECTION_SENSOR = "hp_uptime_connection_sensor"
 CONF_USE_AS_OPERATING_FALLBACK = "use_as_operating_fallback"  # Nouvelle constante
 CONF_FAHRENHEIT_SUPPORT_MODE = "fahrenheit_compatibility"
@@ -135,7 +139,7 @@ CONF_DEBOUNCE_DELAY = "debounce_delay"
 CONF_CONNECTION_BOOTSTRAP_DELAY = "connection_bootstrap_delay"
 CONF_INSTALLER_MODE = "installer_mode"
 
-# Définitions des classes C++ (identiques à votre version)
+# DÃ©finitions des classes C++ (identiques Ã  votre version)
 VaneOrientationSelect = cg.global_ns.class_(
     "VaneOrientationSelect", select.Select, cg.Component
 )
@@ -161,6 +165,12 @@ SubModSensor = cg.global_ns.class_("SubModSensor", text_sensor.TextSensor, cg.Co
 AutoSubModSensor = cg.global_ns.class_(
     "AutoSubModSensor", text_sensor.TextSensor, cg.Component
 )
+ErrorCodeSensor = cg.global_ns.class_(
+    "ErrorCodeSensor", text_sensor.TextSensor, cg.Component
+)
+RemoteTempSourceInfo = cg.global_ns.class_(
+    "RemoteTempSourceInfo", text_sensor.TextSensor, cg.Component
+)
 cn105_ns = cg.esphome_ns.namespace("cn105")
 HpUpTimeConnectionSensor = cn105_ns.class_(
     "HpUpTimeConnectionSensor", sensor.Sensor, cg.PollingComponent
@@ -174,7 +184,7 @@ HardwareSettingSelect = cg.global_ns.class_(
 )
 
 
-# --- Fonction d'aide pour récupérer les pins TX/RX (identique à votre version corrigée) ---
+# --- Fonction d'aide pour rÃ©cupÃ©rer les pins TX/RX (identique Ã  votre version corrigÃ©e) ---
 def get_uart_pins_from_config(core_config, target_uart_id_str):
     tx_pin_num = -1
     rx_pin_num = -1
@@ -200,9 +210,9 @@ def get_uart_pins_from_config(core_config, target_uart_id_str):
 
 
 def get_uart_port_index(core_config, target_uart_id_str):
-    # ESPHome ne fournit pas directement l'index de contrôleur; on l'infère
-    # via l'ordre de déclaration ou restons à 0 par défaut.
-    # On tente d'associer l'objet id() à sa position.
+    # ESPHome ne fournit pas directement l'index de contrÃ´leur; on l'infÃ¨re
+    # via l'ordre de dÃ©claration ou restons Ã  0 par dÃ©faut.
+    # On tente d'associer l'objet id() Ã  sa position.
     idx = 0
     for i, uart_conf_item in enumerate(core_config.get("uart", [])):
         if str(uart_conf_item[CONF_ID]) == target_uart_id_str:
@@ -218,7 +228,7 @@ def get_uart_port_index(core_config, target_uart_id_str):
 
 # --- FIN de la fonction d'aide ---
 
-# Schémas pour les entités optionnelles (identiques à votre version)
+# SchÃ©mas pour les entitÃ©s optionnelles (identiques Ã  votre version)
 SELECT_SCHEMA = select.select_schema(VaneOrientationSelect).extend(
     {cv.GenerateID(CONF_ID): cv.declare_id(VaneOrientationSelect)}
 )
@@ -288,15 +298,15 @@ REMOTE_TEMPERATURE_CONTROL_SENSOR_SCHEMA = binary_sensor.binary_sensor_schema(
     }
 )
 
-# Schéma pour STAGE_SENSOR (qui est un text_sensor) AVEC la nouvelle sous-option
+# SchÃ©ma pour STAGE_SENSOR (qui est un text_sensor) AVEC la nouvelle sous-option
 STAGE_SENSOR_CONFIG_SCHEMA = text_sensor.text_sensor_schema(StageSensor).extend(
     {
-        # L'ID pour l'objet StageSensor C++ est géré par text_sensor.TEXT_SENSOR_SCHEMA (via CONF_ID)
+        # L'ID pour l'objet StageSensor C++ est gÃ©rÃ© par text_sensor.TEXT_SENSOR_SCHEMA (via CONF_ID)
         cv.Optional(CONF_USE_AS_OPERATING_FALLBACK, default=False): cv.boolean,
     }
 )
 
-# Schéma pour HP_UP_TIME_CONNECTION_SENSOR (identique à votre version)
+# SchÃ©ma pour HP_UP_TIME_CONNECTION_SENSOR (identique Ã  votre version)
 HP_UP_TIME_CONNECTION_SENSOR_SCHEMA = sensor.sensor_schema(
     HpUpTimeConnectionSensor,
     unit_of_measurement=UNIT_SECOND,
@@ -365,9 +375,11 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(
                 CONF_STAGE_SENSOR
-            ): STAGE_SENSOR_CONFIG_SCHEMA,  # Modifié pour le nouveau schéma
+            ): STAGE_SENSOR_CONFIG_SCHEMA,  # ModifiÃ© pour le nouveau schÃ©ma
             cv.Optional(CONF_SUB_MODE_SENSOR): SUB_MODE_SENSOR_SCHEMA,
             cv.Optional(CONF_AUTO_SUB_MODE_SENSOR): AUTO_SUB_MODE_SENSOR_SCHEMA,
+            cv.Optional(CONF_ERROR_CODE_SENSOR): ERROR_CODE_SENSOR_SCHEMA,
+            cv.Optional(CONF_REMOTE_TEMP_SOURCE): REMOTE_TEMP_SOURCE_SCHEMA,
             cv.Optional(CONF_REMOTE_TEMP_TIMEOUT, default="never"): cv.All(
                 cv.update_interval
             ),
@@ -451,7 +463,7 @@ def to_code(config):
         supports = config[CONF_SUPPORTS]
         traits = var.config_traits()
 
-        # Configurer les modes supportés
+        # Configurer les modes supportÃ©s
         supported_modes = supports.get(CONF_MODE, DEFAULT_CLIMATE_MODES)
         for mode_str in supported_modes:
             if mode_str == "OFF":
@@ -520,7 +532,7 @@ def to_code(config):
         )
     )
 
-    # --- Configuration des entités optionnelles (style original) ---
+    # --- Configuration des entitÃ©s optionnelles (style original) ---
     if CONF_HORIZONTAL_SWING_SELECT in config:
         conf_item = config[CONF_HORIZONTAL_SWING_SELECT]
         # new_select s'occupe de l'enregistrement. options=[] est important.
@@ -545,15 +557,15 @@ def to_code(config):
         control_select_var = yield select.new_select(conf_item, options=[])
         cg.add(var.set_airflow_control_select(control_select_var))
 
-    # Pour les capteurs, text_sensors, etc., utiliser la méthode .new_... standard
+    # Pour les capteurs, text_sensors, etc., utiliser la mÃ©thode .new_... standard
     # Ces fonctions s'occupent de l'enregistrement du composant.
     if CONF_COMPRESSOR_FREQUENCY_SENSOR in config:
-        # conf = config[CONF_COMPRESSOR_FREQUENCY_SENSOR] # 'conf' est déjà utilisé comme argument de to_code
-        # conf["force_update"] = False # Ceci était dans votre code original, le garder si pertinent
+        # conf = config[CONF_COMPRESSOR_FREQUENCY_SENSOR] # 'conf' est dÃ©jÃ  utilisÃ© comme argument de to_code
+        # conf["force_update"] = False # Ceci Ã©tait dans votre code original, le garder si pertinent
         conf_item = config[CONF_COMPRESSOR_FREQUENCY_SENSOR]
         if (
             "force_update" not in conf_item
-        ):  # S'assurer de ne pas l'écraser si l'user l'a mis
+        ):  # S'assurer de ne pas l'Ã©craser si l'user l'a mis
             conf_item["force_update"] = False
         sensor_var = yield sensor.new_sensor(conf_item)
         cg.add(var.set_compressor_frequency_sensor(sensor_var))
@@ -645,7 +657,7 @@ def to_code(config):
     # --- TRAITEMENT POUR STAGE_SENSOR AVEC LA NOUVELLE OPTION ---
     if CONF_STAGE_SENSOR in config:
         conf_stage_dict = config[CONF_STAGE_SENSOR]
-        # new_text_sensor gère la création et l'enregistrement de base du text_sensor
+        # new_text_sensor gÃ¨re la crÃ©ation et l'enregistrement de base du text_sensor
         stage_ts_var = yield text_sensor.new_text_sensor(conf_stage_dict)
         cg.add(var.set_stage_sensor(stage_ts_var))
 
@@ -673,6 +685,20 @@ def to_code(config):
             config[CONF_AUTO_SUB_MODE_SENSOR]
         )
         cg.add(var.set_auto_sub_mode_sensor(tsensor_var))
+
+    if CONF_ERROR_CODE_SENSOR in config:
+        tsensor_var = yield text_sensor.new_text_sensor(
+            config[CONF_ERROR_CODE_SENSOR]
+        )
+        cg.add(var.set_error_code_sensor(tsensor_var))
+
+    if CONF_REMOTE_TEMP_SOURCE in config:
+        rts_config = config[CONF_REMOTE_TEMP_SOURCE]
+        source_sensor = yield cg.get_variable(rts_config[CONF_REMOTE_TEMP_SOURCE_SENSOR_ID])
+        cg.add(var.set_remote_temp_source(source_sensor))
+        if CONF_REMOTE_TEMP_SOURCE_INFO in rts_config:
+            info_sensor = yield text_sensor.new_text_sensor(rts_config[CONF_REMOTE_TEMP_SOURCE_INFO])
+            cg.add(var.set_remote_temp_source_info_sensor(info_sensor))
 
     if CONF_HP_UP_TIME_CONNECTION_SENSOR in config:
         conf = config[CONF_HP_UP_TIME_CONNECTION_SENSOR]

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -54,7 +54,7 @@ from esphome.components.sensor import (
 )
 from esphome.core import CORE, coroutine
 
-# ... (AUTO_LOAD, DEPENDENCIES, toutes les constantes CONF_XXX_SENSOR, DEFAULT_MODES - identiques ÃÂ  votre version) ...
+# ... (AUTO_LOAD, DEPENDENCIES, toutes les constantes CONF_XXX_SENSOR, DEFAULT_MODES - identiques ÃÂÃÂ  votre version) ...
 AUTO_LOAD = [
     "climate",
     "sensor",
@@ -98,7 +98,7 @@ CONF_AUTO_SUB_MODE_SENSOR = "auto_sub_mode_sensor"
 CONF_ERROR_CODE_SENSOR = "error_code_sensor"
 CONF_REMOTE_TEMP_SOURCE = "remote_temperature_source"
 CONF_REMOTE_TEMP_SOURCE_SENSOR_ID = "sensor_id"
-CONF_REMOTE_TEMP_SOURCE_INFO = "remote_temperature_source_info"
+CONF_REMOTE_TEMP_SOURCE_INFO = "info"
 CONF_HP_UP_TIME_CONNECTION_SENSOR = "hp_uptime_connection_sensor"
 CONF_USE_AS_OPERATING_FALLBACK = "use_as_operating_fallback"  # Nouvelle constante
 CONF_FAHRENHEIT_SUPPORT_MODE = "fahrenheit_compatibility"
@@ -139,7 +139,7 @@ CONF_DEBOUNCE_DELAY = "debounce_delay"
 CONF_CONNECTION_BOOTSTRAP_DELAY = "connection_bootstrap_delay"
 CONF_INSTALLER_MODE = "installer_mode"
 
-# DÃÂ©finitions des classes C++ (identiques ÃÂ  votre version)
+# DÃÂÃÂ©finitions des classes C++ (identiques ÃÂÃÂ  votre version)
 VaneOrientationSelect = cg.global_ns.class_(
     "VaneOrientationSelect", select.Select, cg.Component
 )
@@ -184,7 +184,7 @@ HardwareSettingSelect = cg.global_ns.class_(
 )
 
 
-# --- Fonction d'aide pour rÃÂ©cupÃÂ©rer les pins TX/RX (identique ÃÂ  votre version corrigÃÂ©e) ---
+# --- Fonction d'aide pour rÃÂÃÂ©cupÃÂÃÂ©rer les pins TX/RX (identique ÃÂÃÂ  votre version corrigÃÂÃÂ©e) ---
 def get_uart_pins_from_config(core_config, target_uart_id_str):
     tx_pin_num = -1
     rx_pin_num = -1
@@ -210,9 +210,9 @@ def get_uart_pins_from_config(core_config, target_uart_id_str):
 
 
 def get_uart_port_index(core_config, target_uart_id_str):
-    # ESPHome ne fournit pas directement l'index de contrÃÂ´leur; on l'infÃÂ¨re
-    # via l'ordre de dÃÂ©claration ou restons ÃÂ  0 par dÃÂ©faut.
-    # On tente d'associer l'objet id() ÃÂ  sa position.
+    # ESPHome ne fournit pas directement l'index de contrÃÂÃÂ´leur; on l'infÃÂÃÂ¨re
+    # via l'ordre de dÃÂÃÂ©claration ou restons ÃÂÃÂ  0 par dÃÂÃÂ©faut.
+    # On tente d'associer l'objet id() ÃÂÃÂ  sa position.
     idx = 0
     for i, uart_conf_item in enumerate(core_config.get("uart", [])):
         if str(uart_conf_item[CONF_ID]) == target_uart_id_str:
@@ -228,7 +228,7 @@ def get_uart_port_index(core_config, target_uart_id_str):
 
 # --- FIN de la fonction d'aide ---
 
-# SchÃÂ©mas pour les entitÃÂ©s optionnelles (identiques ÃÂ  votre version)
+# SchÃÂÃÂ©mas pour les entitÃÂÃÂ©s optionnelles (identiques ÃÂÃÂ  votre version)
 SELECT_SCHEMA = select.select_schema(VaneOrientationSelect).extend(
     {cv.GenerateID(CONF_ID): cv.declare_id(VaneOrientationSelect)}
 )
@@ -311,15 +311,15 @@ REMOTE_TEMPERATURE_CONTROL_SENSOR_SCHEMA = binary_sensor.binary_sensor_schema(
     }
 )
 
-# SchÃÂ©ma pour STAGE_SENSOR (qui est un text_sensor) AVEC la nouvelle sous-option
+# SchÃÂÃÂ©ma pour STAGE_SENSOR (qui est un text_sensor) AVEC la nouvelle sous-option
 STAGE_SENSOR_CONFIG_SCHEMA = text_sensor.text_sensor_schema(StageSensor).extend(
     {
-        # L'ID pour l'objet StageSensor C++ est gÃÂ©rÃÂ© par text_sensor.TEXT_SENSOR_SCHEMA (via CONF_ID)
+        # L'ID pour l'objet StageSensor C++ est gÃÂÃÂ©rÃÂÃÂ© par text_sensor.TEXT_SENSOR_SCHEMA (via CONF_ID)
         cv.Optional(CONF_USE_AS_OPERATING_FALLBACK, default=False): cv.boolean,
     }
 )
 
-# SchÃÂ©ma pour HP_UP_TIME_CONNECTION_SENSOR (identique ÃÂ  votre version)
+# SchÃÂÃÂ©ma pour HP_UP_TIME_CONNECTION_SENSOR (identique ÃÂÃÂ  votre version)
 HP_UP_TIME_CONNECTION_SENSOR_SCHEMA = sensor.sensor_schema(
     HpUpTimeConnectionSensor,
     unit_of_measurement=UNIT_SECOND,
@@ -388,7 +388,7 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(
                 CONF_STAGE_SENSOR
-            ): STAGE_SENSOR_CONFIG_SCHEMA,  # ModifiÃÂ© pour le nouveau schÃÂ©ma
+            ): STAGE_SENSOR_CONFIG_SCHEMA,  # ModifiÃÂÃÂ© pour le nouveau schÃÂÃÂ©ma
             cv.Optional(CONF_SUB_MODE_SENSOR): SUB_MODE_SENSOR_SCHEMA,
             cv.Optional(CONF_AUTO_SUB_MODE_SENSOR): AUTO_SUB_MODE_SENSOR_SCHEMA,
             cv.Optional(CONF_ERROR_CODE_SENSOR): ERROR_CODE_SENSOR_SCHEMA,
@@ -476,7 +476,7 @@ def to_code(config):
         supports = config[CONF_SUPPORTS]
         traits = var.config_traits()
 
-        # Configurer les modes supportÃÂ©s
+        # Configurer les modes supportÃÂÃÂ©s
         supported_modes = supports.get(CONF_MODE, DEFAULT_CLIMATE_MODES)
         for mode_str in supported_modes:
             if mode_str == "OFF":
@@ -545,7 +545,7 @@ def to_code(config):
         )
     )
 
-    # --- Configuration des entitÃÂ©s optionnelles (style original) ---
+    # --- Configuration des entitÃÂÃÂ©s optionnelles (style original) ---
     if CONF_HORIZONTAL_SWING_SELECT in config:
         conf_item = config[CONF_HORIZONTAL_SWING_SELECT]
         # new_select s'occupe de l'enregistrement. options=[] est important.
@@ -570,15 +570,15 @@ def to_code(config):
         control_select_var = yield select.new_select(conf_item, options=[])
         cg.add(var.set_airflow_control_select(control_select_var))
 
-    # Pour les capteurs, text_sensors, etc., utiliser la mÃÂ©thode .new_... standard
+    # Pour les capteurs, text_sensors, etc., utiliser la mÃÂÃÂ©thode .new_... standard
     # Ces fonctions s'occupent de l'enregistrement du composant.
     if CONF_COMPRESSOR_FREQUENCY_SENSOR in config:
-        # conf = config[CONF_COMPRESSOR_FREQUENCY_SENSOR] # 'conf' est dÃÂ©jÃÂ  utilisÃÂ© comme argument de to_code
-        # conf["force_update"] = False # Ceci ÃÂ©tait dans votre code original, le garder si pertinent
+        # conf = config[CONF_COMPRESSOR_FREQUENCY_SENSOR] # 'conf' est dÃÂÃÂ©jÃÂÃÂ  utilisÃÂÃÂ© comme argument de to_code
+        # conf["force_update"] = False # Ceci ÃÂÃÂ©tait dans votre code original, le garder si pertinent
         conf_item = config[CONF_COMPRESSOR_FREQUENCY_SENSOR]
         if (
             "force_update" not in conf_item
-        ):  # S'assurer de ne pas l'ÃÂ©craser si l'user l'a mis
+        ):  # S'assurer de ne pas l'ÃÂÃÂ©craser si l'user l'a mis
             conf_item["force_update"] = False
         sensor_var = yield sensor.new_sensor(conf_item)
         cg.add(var.set_compressor_frequency_sensor(sensor_var))
@@ -670,7 +670,7 @@ def to_code(config):
     # --- TRAITEMENT POUR STAGE_SENSOR AVEC LA NOUVELLE OPTION ---
     if CONF_STAGE_SENSOR in config:
         conf_stage_dict = config[CONF_STAGE_SENSOR]
-        # new_text_sensor gÃÂ¨re la crÃÂ©ation et l'enregistrement de base du text_sensor
+        # new_text_sensor gÃÂÃÂ¨re la crÃÂÃÂ©ation et l'enregistrement de base du text_sensor
         stage_ts_var = yield text_sensor.new_text_sensor(conf_stage_dict)
         cg.add(var.set_stage_sensor(stage_ts_var))
 

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -25,12 +25,12 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
         [this]() -> CN105Climate* { return this; }
     ) {
 
-    // Active les flags de fonctionnalités via l'API moderne (évite les setters dépréciés)
+    // Active les flags de fonctionnalitÃ©s via l'API moderne (Ã©vite les setters dÃ©prÃ©ciÃ©s)
     this->traits_.add_feature_flags(
         climate::CLIMATE_SUPPORTS_ACTION |
         climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE
     );
-    // supports_two_point_target_temperature sera défini dans setup() selon les modes supportés
+    // supports_two_point_target_temperature sera dÃ©fini dans setup() selon les modes supportÃ©s
     this->traits_.set_visual_min_temperature(ESPMHP_MIN_TEMPERATURE);
     this->traits_.set_visual_max_temperature(ESPMHP_MAX_TEMPERATURE);
     this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
@@ -113,15 +113,15 @@ void CN105Climate::registerInfoRequests() {
     scheduler_.register_request(r_hvac_opts);
 
     // Placeholders
-    InfoRequest r_unknown("unknown", "Unknown", 0x04, 1, 0);
-    //r_unknown.disabled = true;
-    scheduler_.register_request(r_unknown);
+    InfoRequest r_error_info("error_info", "Error Info", 0x04, 3, 0);
+    //r_error_info.disabled = true;
+    scheduler_.register_request(r_error_info);
 
     InfoRequest r_timers("timers", "Timers", 0x05, 1, 0);
     r_timers.disabled = true;
     scheduler_.register_request(r_timers);
 
-    // Appel vers la nouvelle méthode dédiée
+    // Appel vers la nouvelle mÃ©thode dÃ©diÃ©e
     this->registerHardwareSettingsRequests();
 }
 
@@ -130,14 +130,14 @@ void CN105Climate::registerHardwareSettingsRequests() {
         ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval %u ms", this->hardware_settings_interval_ms_);
         uint32_t interval = this->hardware_settings_interval_ms_;
 
-        // Helper Lambda : Vérifie l'incompatibilité et désactive tout si nécessaire
+        // Helper Lambda : VÃ©rifie l'incompatibilitÃ© et dÃ©sactive tout si nÃ©cessaire
         auto check_and_disable = [](CN105Climate& self, uint8_t code) -> bool {
             if (self.data[0] != code) return false;
 
             bool all_zeros = true;
-            // Sur certaines unités (ex: SEZ), les codes peuvent être présents avec une valeur à 0
-            // tant que la session n'est pas en mode installateur. La présence de l'octet (code+valeur)
-            // suffit à valider le support.
+            // Sur certaines unitÃ©s (ex: SEZ), les codes peuvent Ãªtre prÃ©sents avec une valeur Ã  0
+            // tant que la session n'est pas en mode installateur. La prÃ©sence de l'octet (code+valeur)
+            // suffit Ã  valider le support.
             for (int i = 1; i < self.dataLength; i++) {
                 if (self.data[i] != 0) {
                     all_zeros = false;
@@ -148,7 +148,7 @@ void CN105Climate::registerHardwareSettingsRequests() {
             if (all_zeros) {
                 ESP_LOGW(LOG_FUNCTIONS_TAG, "Response 0x%02X contains only zeros. Feature not supported by unit. Disabling.", code);
 
-                // 1. Désactiver la requête via le scheduler
+                // 1. DÃ©sactiver la requÃªte via le scheduler
                 self.scheduler_.disable_request(code);
 
                 // 2. Marquer les composants graphiques comme "Failed" (Unavailable)
@@ -194,8 +194,8 @@ void CN105Climate::registerHardwareSettingsRequests() {
     }
 }
 
-// Les méthodes sendInfoRequest, markResponseSeenFor, sendNextAfter et processInfoResponse
-// ont été déplacées dans RequestScheduler pour respecter le principe de responsabilité unique (SRP).
+// Les mÃ©thodes sendInfoRequest, markResponseSeenFor, sendNextAfter et processInfoResponse
+// ont Ã©tÃ© dÃ©placÃ©es dans RequestScheduler pour respecter le principe de responsabilitÃ© unique (SRP).
 
 
 
@@ -334,11 +334,11 @@ void CN105Climate::setupUART() {
     if (this->parent_->get_data_bits() == 8 &&
         this->parent_->get_parity() == uart::UART_CONFIG_PARITY_EVEN &&
         this->parent_->get_stop_bits() == 1) {
-        ESP_LOGI(LOG_CONN_TAG, "UART configuré en SERIAL_8E1");
+        ESP_LOGI(LOG_CONN_TAG, "UART configurÃ© en SERIAL_8E1");
         this->isUARTConnected_ = true;
         this->initBytePointer();
     } else {
-        ESP_LOGW(LOG_CONN_TAG, "UART n'est pas configuré en SERIAL_8E1");
+        ESP_LOGW(LOG_CONN_TAG, "UART n'est pas configurÃ© en SERIAL_8E1");
     }
 
 }
@@ -370,8 +370,8 @@ void CN105Climate::reconnectUART() {
     ESP_LOGD(TAG, "reconnectUART()");
     this->lastReconnectTimeMs = CUSTOM_MILLIS;
     this->disconnectUART();
-    // Désactivé: le fallback UART bas-niveau (ESP-IDF 5.4.x) peut interférer avec les
-    // tests de handshake/fallback. On laisse UARTComponent gérer la réinit standard.
+    // DÃ©sactivÃ©: le fallback UART bas-niveau (ESP-IDF 5.4.x) peut interfÃ©rer avec les
+    // tests de handshake/fallback. On laisse UARTComponent gÃ©rer la rÃ©init standard.
     this->force_low_level_uart_reinit();
     this->setupUART();
     this->sendFirstConnectionPacket();
@@ -412,8 +412,8 @@ bool CN105Climate::isHeatpumpConnectionActive() {
 
 void CN105Climate::force_low_level_uart_reinit() {
 #ifdef USE_ESP32
-    // Réinit basse couche: reconfigurer le contrôleur utilisé par UARTComponent
-    // On utilise le port passé par set_uart_port (fallback UART0 si inconnu)
+    // RÃ©init basse couche: reconfigurer le contrÃ´leur utilisÃ© par UARTComponent
+    // On utilise le port passÃ© par set_uart_port (fallback UART0 si inconnu)
     const uart_port_t port = (this->uart_port_ == 1) ? UART_NUM_1 :
 #ifdef UART_NUM_2
     (this->uart_port_ == 2) ? UART_NUM_2 :
@@ -422,13 +422,13 @@ void CN105Climate::force_low_level_uart_reinit() {
 
     ESP_LOGI(TAG, "Forcing low-level UART reinit on port %d (tx=%d, rx=%d)", (int)port, this->tx_pin_, this->rx_pin_);
 
-    // IMPORTANT: ne pas supprimer/réinstaller le driver ici pour éviter conflit avec UARTComponent
+    // IMPORTANT: ne pas supprimer/rÃ©installer le driver ici pour Ã©viter conflit avec UARTComponent
     // On reconfigure in-place et on assainit les GPIO
     if (this->tx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->tx_pin_);
     if (this->rx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->rx_pin_);
     CUSTOM_DELAY(2);
 
-    // Paramètres SERIAL_8E1 @ 2400 bauds (valeurs issues de la config UARTComponent)
+    // ParamÃ¨tres SERIAL_8E1 @ 2400 bauds (valeurs issues de la config UARTComponent)
     uart_config_t cfg = {};
     cfg.baud_rate = this->parent_ ? (int)this->parent_->get_baud_rate() : 2400;
     cfg.data_bits = UART_DATA_8_BITS;
@@ -447,7 +447,7 @@ void CN105Climate::force_low_level_uart_reinit() {
         ESP_LOGE(TAG, "uart_set_pin failed: %s", esp_err_to_name(pin_err));
     }
 
-    // RX idle high: assurer un pull-up (utile à bas débit/8E1)
+    // RX idle high: assurer un pull-up (utile Ã  bas dÃ©bit/8E1)
     if (this->rx_pin_ >= 0) {
         gpio_set_pull_mode((gpio_num_t)this->rx_pin_, GPIO_PULLUP_ONLY);
     }
@@ -455,16 +455,16 @@ void CN105Climate::force_low_level_uart_reinit() {
     // S'assurer du mode UART classique
     uart_set_mode(port, UART_MODE_UART);
 
-    // Attendre que toute TX en cours finisse (si driver déjà installé)
+    // Attendre que toute TX en cours finisse (si driver dÃ©jÃ  installÃ©)
     uart_wait_tx_done(port, pdMS_TO_TICKS(20));
 
-    // Fixer la source d'horloge UART (bas débits peuvent être sensibles)
+    // Fixer la source d'horloge UART (bas dÃ©bits peuvent Ãªtre sensibles)
 #if defined(UART_SCLK_XTAL)
     uart_set_sclk(port, UART_SCLK_XTAL);
 #elif defined(UART_SCLK_APB)
     uart_set_sclk(port, UART_SCLK_APB);
 #endif
-    // Re-forcer explicitement le baud après sclk
+    // Re-forcer explicitement le baud aprÃ¨s sclk
     uart_set_baudrate(port, cfg.baud_rate);
 
     // Assainir inversion/flow control
@@ -474,7 +474,7 @@ void CN105Climate::force_low_level_uart_reinit() {
     // Timeout RX court pour vider rapidement
     uart_set_rx_timeout(port, 2);
 
-    // Purger les buffers pour éviter les résidus
+    // Purger les buffers pour Ã©viter les rÃ©sidus
     uart_flush_input(port);
     CUSTOM_DELAY(2);
 
@@ -483,6 +483,6 @@ void CN105Climate::force_low_level_uart_reinit() {
     uart_get_baudrate(port, &eff_baud);
     ESP_LOGD(TAG, "UART effective baud=%lu tx_pin=%d rx_pin=%d", (unsigned long)eff_baud, this->tx_pin_, this->rx_pin_);
 #else
-    // Pas d’ESP32: rien à faire
+    // Pas dâESP32: rien Ã  faire
 #endif
 }

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -114,7 +114,7 @@ void CN105Climate::registerInfoRequests() {
 
     // Placeholders
     InfoRequest r_error_info("error_info", "Error Info", 0x04, 3, 0);
-    //r_error_info.disabled = true;
+    r_error_info.onResponse = [this](CN105Climate& self) { (void)self; this->getErrorInfoFromResponsePacket(); };
     scheduler_.register_request(r_error_info);
 
     InfoRequest r_timers("timers", "Timers", 0x05, 1, 0);

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -25,12 +25,12 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
         [this]() -> CN105Climate* { return this; }
     ) {
 
-    // Active les flags de fonctionnalitÃÂÃÂ©s via l'API moderne (ÃÂÃÂ©vite les setters dÃÂÃÂ©prÃÂÃÂ©ciÃÂÃÂ©s)
+    // Active les flags de fonctionnalitÃÂÃÂÃÂÃÂ©s via l'API moderne (ÃÂÃÂÃÂÃÂ©vite les setters dÃÂÃÂÃÂÃÂ©prÃÂÃÂÃÂÃÂ©ciÃÂÃÂÃÂÃÂ©s)
     this->traits_.add_feature_flags(
         climate::CLIMATE_SUPPORTS_ACTION |
         climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE
     );
-    // supports_two_point_target_temperature sera dÃÂÃÂ©fini dans setup() selon les modes supportÃÂÃÂ©s
+    // supports_two_point_target_temperature sera dÃÂÃÂÃÂÃÂ©fini dans setup() selon les modes supportÃÂÃÂÃÂÃÂ©s
     this->traits_.set_visual_min_temperature(ESPMHP_MIN_TEMPERATURE);
     this->traits_.set_visual_max_temperature(ESPMHP_MAX_TEMPERATURE);
     this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
@@ -114,15 +114,14 @@ void CN105Climate::registerInfoRequests() {
 
     // Placeholders
     InfoRequest r_error_info("error_info", "Error Info", 0x04, 3, 0);
-    //r_error_info.onResponse = [this](CN105Climate* self) { (void)self; this->getErrorInfoFromResponsePacket(); };
-    r_error_info.disabled = (this->error_code_sensor_ == nullptr);
+    //r_error_info.disabled = true;
     scheduler_.register_request(r_error_info);
 
     InfoRequest r_timers("timers", "Timers", 0x05, 1, 0);
     r_timers.disabled = true;
     scheduler_.register_request(r_timers);
 
-    // Appel vers la nouvelle mÃÂÃÂ©thode dÃÂÃÂ©diÃÂÃÂ©e
+    // Appel vers la nouvelle mÃÂÃÂÃÂÃÂ©thode dÃÂÃÂÃÂÃÂ©diÃÂÃÂÃÂÃÂ©e
     this->registerHardwareSettingsRequests();
 }
 
@@ -131,14 +130,14 @@ void CN105Climate::registerHardwareSettingsRequests() {
         ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval %u ms", this->hardware_settings_interval_ms_);
         uint32_t interval = this->hardware_settings_interval_ms_;
 
-        // Helper Lambda : VÃÂÃÂ©rifie l'incompatibilitÃÂÃÂ© et dÃÂÃÂ©sactive tout si nÃÂÃÂ©cessaire
+        // Helper Lambda : VÃÂÃÂÃÂÃÂ©rifie l'incompatibilitÃÂÃÂÃÂÃÂ© et dÃÂÃÂÃÂÃÂ©sactive tout si nÃÂÃÂÃÂÃÂ©cessaire
         auto check_and_disable = [](CN105Climate& self, uint8_t code) -> bool {
             if (self.data[0] != code) return false;
 
             bool all_zeros = true;
-            // Sur certaines unitÃÂÃÂ©s (ex: SEZ), les codes peuvent ÃÂÃÂªtre prÃÂÃÂ©sents avec une valeur ÃÂÃÂ  0
-            // tant que la session n'est pas en mode installateur. La prÃÂÃÂ©sence de l'octet (code+valeur)
-            // suffit ÃÂÃÂ  valider le support.
+            // Sur certaines unitÃÂÃÂÃÂÃÂ©s (ex: SEZ), les codes peuvent ÃÂÃÂÃÂÃÂªtre prÃÂÃÂÃÂÃÂ©sents avec une valeur ÃÂÃÂÃÂÃÂ  0
+            // tant que la session n'est pas en mode installateur. La prÃÂÃÂÃÂÃÂ©sence de l'octet (code+valeur)
+            // suffit ÃÂÃÂÃÂÃÂ  valider le support.
             for (int i = 1; i < self.dataLength; i++) {
                 if (self.data[i] != 0) {
                     all_zeros = false;
@@ -149,7 +148,7 @@ void CN105Climate::registerHardwareSettingsRequests() {
             if (all_zeros) {
                 ESP_LOGW(LOG_FUNCTIONS_TAG, "Response 0x%02X contains only zeros. Feature not supported by unit. Disabling.", code);
 
-                // 1. DÃÂÃÂ©sactiver la requÃÂÃÂªte via le scheduler
+                // 1. DÃÂÃÂÃÂÃÂ©sactiver la requÃÂÃÂÃÂÃÂªte via le scheduler
                 self.scheduler_.disable_request(code);
 
                 // 2. Marquer les composants graphiques comme "Failed" (Unavailable)
@@ -195,8 +194,8 @@ void CN105Climate::registerHardwareSettingsRequests() {
     }
 }
 
-// Les mÃÂÃÂ©thodes sendInfoRequest, markResponseSeenFor, sendNextAfter et processInfoResponse
-// ont ÃÂÃÂ©tÃÂÃÂ© dÃÂÃÂ©placÃÂÃÂ©es dans RequestScheduler pour respecter le principe de responsabilitÃÂÃÂ© unique (SRP).
+// Les mÃÂÃÂÃÂÃÂ©thodes sendInfoRequest, markResponseSeenFor, sendNextAfter et processInfoResponse
+// ont ÃÂÃÂÃÂÃÂ©tÃÂÃÂÃÂÃÂ© dÃÂÃÂÃÂÃÂ©placÃÂÃÂÃÂÃÂ©es dans RequestScheduler pour respecter le principe de responsabilitÃÂÃÂÃÂÃÂ© unique (SRP).
 
 
 
@@ -335,11 +334,11 @@ void CN105Climate::setupUART() {
     if (this->parent_->get_data_bits() == 8 &&
         this->parent_->get_parity() == uart::UART_CONFIG_PARITY_EVEN &&
         this->parent_->get_stop_bits() == 1) {
-        ESP_LOGI(LOG_CONN_TAG, "UART configurÃÂÃÂ© en SERIAL_8E1");
+        ESP_LOGI(LOG_CONN_TAG, "UART configurÃÂÃÂÃÂÃÂ© en SERIAL_8E1");
         this->isUARTConnected_ = true;
         this->initBytePointer();
     } else {
-        ESP_LOGW(LOG_CONN_TAG, "UART n'est pas configurÃÂÃÂ© en SERIAL_8E1");
+        ESP_LOGW(LOG_CONN_TAG, "UART n'est pas configurÃÂÃÂÃÂÃÂ© en SERIAL_8E1");
     }
 
 }
@@ -371,8 +370,8 @@ void CN105Climate::reconnectUART() {
     ESP_LOGD(TAG, "reconnectUART()");
     this->lastReconnectTimeMs = CUSTOM_MILLIS;
     this->disconnectUART();
-    // DÃÂÃÂ©sactivÃÂÃÂ©: le fallback UART bas-niveau (ESP-IDF 5.4.x) peut interfÃÂÃÂ©rer avec les
-    // tests de handshake/fallback. On laisse UARTComponent gÃÂÃÂ©rer la rÃÂÃÂ©init standard.
+    // DÃÂÃÂÃÂÃÂ©sactivÃÂÃÂÃÂÃÂ©: le fallback UART bas-niveau (ESP-IDF 5.4.x) peut interfÃÂÃÂÃÂÃÂ©rer avec les
+    // tests de handshake/fallback. On laisse UARTComponent gÃÂÃÂÃÂÃÂ©rer la rÃÂÃÂÃÂÃÂ©init standard.
     this->force_low_level_uart_reinit();
     this->setupUART();
     this->sendFirstConnectionPacket();
@@ -413,8 +412,8 @@ bool CN105Climate::isHeatpumpConnectionActive() {
 
 void CN105Climate::force_low_level_uart_reinit() {
 #ifdef USE_ESP32
-    // RÃÂÃÂ©init basse couche: reconfigurer le contrÃÂÃÂ´leur utilisÃÂÃÂ© par UARTComponent
-    // On utilise le port passÃÂÃÂ© par set_uart_port (fallback UART0 si inconnu)
+    // RÃÂÃÂÃÂÃÂ©init basse couche: reconfigurer le contrÃÂÃÂÃÂÃÂ´leur utilisÃÂÃÂÃÂÃÂ© par UARTComponent
+    // On utilise le port passÃÂÃÂÃÂÃÂ© par set_uart_port (fallback UART0 si inconnu)
     const uart_port_t port = (this->uart_port_ == 1) ? UART_NUM_1 :
 #ifdef UART_NUM_2
     (this->uart_port_ == 2) ? UART_NUM_2 :
@@ -423,13 +422,13 @@ void CN105Climate::force_low_level_uart_reinit() {
 
     ESP_LOGI(TAG, "Forcing low-level UART reinit on port %d (tx=%d, rx=%d)", (int)port, this->tx_pin_, this->rx_pin_);
 
-    // IMPORTANT: ne pas supprimer/rÃÂÃÂ©installer le driver ici pour ÃÂÃÂ©viter conflit avec UARTComponent
+    // IMPORTANT: ne pas supprimer/rÃÂÃÂÃÂÃÂ©installer le driver ici pour ÃÂÃÂÃÂÃÂ©viter conflit avec UARTComponent
     // On reconfigure in-place et on assainit les GPIO
     if (this->tx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->tx_pin_);
     if (this->rx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->rx_pin_);
     CUSTOM_DELAY(2);
 
-    // ParamÃÂÃÂ¨tres SERIAL_8E1 @ 2400 bauds (valeurs issues de la config UARTComponent)
+    // ParamÃÂÃÂÃÂÃÂ¨tres SERIAL_8E1 @ 2400 bauds (valeurs issues de la config UARTComponent)
     uart_config_t cfg = {};
     cfg.baud_rate = this->parent_ ? (int)this->parent_->get_baud_rate() : 2400;
     cfg.data_bits = UART_DATA_8_BITS;
@@ -448,7 +447,7 @@ void CN105Climate::force_low_level_uart_reinit() {
         ESP_LOGE(TAG, "uart_set_pin failed: %s", esp_err_to_name(pin_err));
     }
 
-    // RX idle high: assurer un pull-up (utile ÃÂÃÂ  bas dÃÂÃÂ©bit/8E1)
+    // RX idle high: assurer un pull-up (utile ÃÂÃÂÃÂÃÂ  bas dÃÂÃÂÃÂÃÂ©bit/8E1)
     if (this->rx_pin_ >= 0) {
         gpio_set_pull_mode((gpio_num_t)this->rx_pin_, GPIO_PULLUP_ONLY);
     }
@@ -456,16 +455,16 @@ void CN105Climate::force_low_level_uart_reinit() {
     // S'assurer du mode UART classique
     uart_set_mode(port, UART_MODE_UART);
 
-    // Attendre que toute TX en cours finisse (si driver dÃÂÃÂ©jÃÂÃÂ  installÃÂÃÂ©)
+    // Attendre que toute TX en cours finisse (si driver dÃÂÃÂÃÂÃÂ©jÃÂÃÂÃÂÃÂ  installÃÂÃÂÃÂÃÂ©)
     uart_wait_tx_done(port, pdMS_TO_TICKS(20));
 
-    // Fixer la source d'horloge UART (bas dÃÂÃÂ©bits peuvent ÃÂÃÂªtre sensibles)
+    // Fixer la source d'horloge UART (bas dÃÂÃÂÃÂÃÂ©bits peuvent ÃÂÃÂÃÂÃÂªtre sensibles)
 #if defined(UART_SCLK_XTAL)
     uart_set_sclk(port, UART_SCLK_XTAL);
 #elif defined(UART_SCLK_APB)
     uart_set_sclk(port, UART_SCLK_APB);
 #endif
-    // Re-forcer explicitement le baud aprÃÂÃÂ¨s sclk
+    // Re-forcer explicitement le baud aprÃÂÃÂÃÂÃÂ¨s sclk
     uart_set_baudrate(port, cfg.baud_rate);
 
     // Assainir inversion/flow control
@@ -475,7 +474,7 @@ void CN105Climate::force_low_level_uart_reinit() {
     // Timeout RX court pour vider rapidement
     uart_set_rx_timeout(port, 2);
 
-    // Purger les buffers pour ÃÂÃÂ©viter les rÃÂÃÂ©sidus
+    // Purger les buffers pour ÃÂÃÂÃÂÃÂ©viter les rÃÂÃÂÃÂÃÂ©sidus
     uart_flush_input(port);
     CUSTOM_DELAY(2);
 
@@ -484,6 +483,6 @@ void CN105Climate::force_low_level_uart_reinit() {
     uart_get_baudrate(port, &eff_baud);
     ESP_LOGD(TAG, "UART effective baud=%lu tx_pin=%d rx_pin=%d", (unsigned long)eff_baud, this->tx_pin_, this->rx_pin_);
 #else
-    // Pas dÃÂ¢ÃÂÃÂESP32: rien ÃÂÃÂ  faire
+    // Pas dÃÂÃÂ¢ÃÂÃÂÃÂÃÂESP32: rien ÃÂÃÂÃÂÃÂ  faire
 #endif
 }

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -25,12 +25,12 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
         [this]() -> CN105Climate* { return this; }
     ) {
 
-    // Active les flags de fonctionnalitÃÂ©s via l'API moderne (ÃÂ©vite les setters dÃÂ©prÃÂ©ciÃÂ©s)
+    // Active les flags de fonctionnalitÃÂÃÂ©s via l'API moderne (ÃÂÃÂ©vite les setters dÃÂÃÂ©prÃÂÃÂ©ciÃÂÃÂ©s)
     this->traits_.add_feature_flags(
         climate::CLIMATE_SUPPORTS_ACTION |
         climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE
     );
-    // supports_two_point_target_temperature sera dÃÂ©fini dans setup() selon les modes supportÃÂ©s
+    // supports_two_point_target_temperature sera dÃÂÃÂ©fini dans setup() selon les modes supportÃÂÃÂ©s
     this->traits_.set_visual_min_temperature(ESPMHP_MIN_TEMPERATURE);
     this->traits_.set_visual_max_temperature(ESPMHP_MAX_TEMPERATURE);
     this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
@@ -114,7 +114,7 @@ void CN105Climate::registerInfoRequests() {
 
     // Placeholders
     InfoRequest r_error_info("error_info", "Error Info", 0x04, 3, 0);
-    //r_error_info.onResponse = [this](CN105Climate* self) { self->getErrorInfoFromResponsePacket(); };
+    //r_error_info.onResponse = [this](CN105Climate* self) { (void)self; this->getErrorInfoFromResponsePacket(); };
     r_error_info.disabled = (this->error_code_sensor_ == nullptr);
     scheduler_.register_request(r_error_info);
 
@@ -122,7 +122,7 @@ void CN105Climate::registerInfoRequests() {
     r_timers.disabled = true;
     scheduler_.register_request(r_timers);
 
-    // Appel vers la nouvelle mÃÂ©thode dÃÂ©diÃÂ©e
+    // Appel vers la nouvelle mÃÂÃÂ©thode dÃÂÃÂ©diÃÂÃÂ©e
     this->registerHardwareSettingsRequests();
 }
 
@@ -131,14 +131,14 @@ void CN105Climate::registerHardwareSettingsRequests() {
         ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval %u ms", this->hardware_settings_interval_ms_);
         uint32_t interval = this->hardware_settings_interval_ms_;
 
-        // Helper Lambda : VÃÂ©rifie l'incompatibilitÃÂ© et dÃÂ©sactive tout si nÃÂ©cessaire
+        // Helper Lambda : VÃÂÃÂ©rifie l'incompatibilitÃÂÃÂ© et dÃÂÃÂ©sactive tout si nÃÂÃÂ©cessaire
         auto check_and_disable = [](CN105Climate& self, uint8_t code) -> bool {
             if (self.data[0] != code) return false;
 
             bool all_zeros = true;
-            // Sur certaines unitÃÂ©s (ex: SEZ), les codes peuvent ÃÂªtre prÃÂ©sents avec une valeur ÃÂ  0
-            // tant que la session n'est pas en mode installateur. La prÃÂ©sence de l'octet (code+valeur)
-            // suffit ÃÂ  valider le support.
+            // Sur certaines unitÃÂÃÂ©s (ex: SEZ), les codes peuvent ÃÂÃÂªtre prÃÂÃÂ©sents avec une valeur ÃÂÃÂ  0
+            // tant que la session n'est pas en mode installateur. La prÃÂÃÂ©sence de l'octet (code+valeur)
+            // suffit ÃÂÃÂ  valider le support.
             for (int i = 1; i < self.dataLength; i++) {
                 if (self.data[i] != 0) {
                     all_zeros = false;
@@ -149,7 +149,7 @@ void CN105Climate::registerHardwareSettingsRequests() {
             if (all_zeros) {
                 ESP_LOGW(LOG_FUNCTIONS_TAG, "Response 0x%02X contains only zeros. Feature not supported by unit. Disabling.", code);
 
-                // 1. DÃÂ©sactiver la requÃÂªte via le scheduler
+                // 1. DÃÂÃÂ©sactiver la requÃÂÃÂªte via le scheduler
                 self.scheduler_.disable_request(code);
 
                 // 2. Marquer les composants graphiques comme "Failed" (Unavailable)
@@ -195,8 +195,8 @@ void CN105Climate::registerHardwareSettingsRequests() {
     }
 }
 
-// Les mÃÂ©thodes sendInfoRequest, markResponseSeenFor, sendNextAfter et processInfoResponse
-// ont ÃÂ©tÃÂ© dÃÂ©placÃÂ©es dans RequestScheduler pour respecter le principe de responsabilitÃÂ© unique (SRP).
+// Les mÃÂÃÂ©thodes sendInfoRequest, markResponseSeenFor, sendNextAfter et processInfoResponse
+// ont ÃÂÃÂ©tÃÂÃÂ© dÃÂÃÂ©placÃÂÃÂ©es dans RequestScheduler pour respecter le principe de responsabilitÃÂÃÂ© unique (SRP).
 
 
 
@@ -335,11 +335,11 @@ void CN105Climate::setupUART() {
     if (this->parent_->get_data_bits() == 8 &&
         this->parent_->get_parity() == uart::UART_CONFIG_PARITY_EVEN &&
         this->parent_->get_stop_bits() == 1) {
-        ESP_LOGI(LOG_CONN_TAG, "UART configurÃÂ© en SERIAL_8E1");
+        ESP_LOGI(LOG_CONN_TAG, "UART configurÃÂÃÂ© en SERIAL_8E1");
         this->isUARTConnected_ = true;
         this->initBytePointer();
     } else {
-        ESP_LOGW(LOG_CONN_TAG, "UART n'est pas configurÃÂ© en SERIAL_8E1");
+        ESP_LOGW(LOG_CONN_TAG, "UART n'est pas configurÃÂÃÂ© en SERIAL_8E1");
     }
 
 }
@@ -371,8 +371,8 @@ void CN105Climate::reconnectUART() {
     ESP_LOGD(TAG, "reconnectUART()");
     this->lastReconnectTimeMs = CUSTOM_MILLIS;
     this->disconnectUART();
-    // DÃÂ©sactivÃÂ©: le fallback UART bas-niveau (ESP-IDF 5.4.x) peut interfÃÂ©rer avec les
-    // tests de handshake/fallback. On laisse UARTComponent gÃÂ©rer la rÃÂ©init standard.
+    // DÃÂÃÂ©sactivÃÂÃÂ©: le fallback UART bas-niveau (ESP-IDF 5.4.x) peut interfÃÂÃÂ©rer avec les
+    // tests de handshake/fallback. On laisse UARTComponent gÃÂÃÂ©rer la rÃÂÃÂ©init standard.
     this->force_low_level_uart_reinit();
     this->setupUART();
     this->sendFirstConnectionPacket();
@@ -413,8 +413,8 @@ bool CN105Climate::isHeatpumpConnectionActive() {
 
 void CN105Climate::force_low_level_uart_reinit() {
 #ifdef USE_ESP32
-    // RÃÂ©init basse couche: reconfigurer le contrÃÂ´leur utilisÃÂ© par UARTComponent
-    // On utilise le port passÃÂ© par set_uart_port (fallback UART0 si inconnu)
+    // RÃÂÃÂ©init basse couche: reconfigurer le contrÃÂÃÂ´leur utilisÃÂÃÂ© par UARTComponent
+    // On utilise le port passÃÂÃÂ© par set_uart_port (fallback UART0 si inconnu)
     const uart_port_t port = (this->uart_port_ == 1) ? UART_NUM_1 :
 #ifdef UART_NUM_2
     (this->uart_port_ == 2) ? UART_NUM_2 :
@@ -423,13 +423,13 @@ void CN105Climate::force_low_level_uart_reinit() {
 
     ESP_LOGI(TAG, "Forcing low-level UART reinit on port %d (tx=%d, rx=%d)", (int)port, this->tx_pin_, this->rx_pin_);
 
-    // IMPORTANT: ne pas supprimer/rÃÂ©installer le driver ici pour ÃÂ©viter conflit avec UARTComponent
+    // IMPORTANT: ne pas supprimer/rÃÂÃÂ©installer le driver ici pour ÃÂÃÂ©viter conflit avec UARTComponent
     // On reconfigure in-place et on assainit les GPIO
     if (this->tx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->tx_pin_);
     if (this->rx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->rx_pin_);
     CUSTOM_DELAY(2);
 
-    // ParamÃÂ¨tres SERIAL_8E1 @ 2400 bauds (valeurs issues de la config UARTComponent)
+    // ParamÃÂÃÂ¨tres SERIAL_8E1 @ 2400 bauds (valeurs issues de la config UARTComponent)
     uart_config_t cfg = {};
     cfg.baud_rate = this->parent_ ? (int)this->parent_->get_baud_rate() : 2400;
     cfg.data_bits = UART_DATA_8_BITS;
@@ -448,7 +448,7 @@ void CN105Climate::force_low_level_uart_reinit() {
         ESP_LOGE(TAG, "uart_set_pin failed: %s", esp_err_to_name(pin_err));
     }
 
-    // RX idle high: assurer un pull-up (utile ÃÂ  bas dÃÂ©bit/8E1)
+    // RX idle high: assurer un pull-up (utile ÃÂÃÂ  bas dÃÂÃÂ©bit/8E1)
     if (this->rx_pin_ >= 0) {
         gpio_set_pull_mode((gpio_num_t)this->rx_pin_, GPIO_PULLUP_ONLY);
     }
@@ -456,16 +456,16 @@ void CN105Climate::force_low_level_uart_reinit() {
     // S'assurer du mode UART classique
     uart_set_mode(port, UART_MODE_UART);
 
-    // Attendre que toute TX en cours finisse (si driver dÃÂ©jÃÂ  installÃÂ©)
+    // Attendre que toute TX en cours finisse (si driver dÃÂÃÂ©jÃÂÃÂ  installÃÂÃÂ©)
     uart_wait_tx_done(port, pdMS_TO_TICKS(20));
 
-    // Fixer la source d'horloge UART (bas dÃÂ©bits peuvent ÃÂªtre sensibles)
+    // Fixer la source d'horloge UART (bas dÃÂÃÂ©bits peuvent ÃÂÃÂªtre sensibles)
 #if defined(UART_SCLK_XTAL)
     uart_set_sclk(port, UART_SCLK_XTAL);
 #elif defined(UART_SCLK_APB)
     uart_set_sclk(port, UART_SCLK_APB);
 #endif
-    // Re-forcer explicitement le baud aprÃÂ¨s sclk
+    // Re-forcer explicitement le baud aprÃÂÃÂ¨s sclk
     uart_set_baudrate(port, cfg.baud_rate);
 
     // Assainir inversion/flow control
@@ -475,7 +475,7 @@ void CN105Climate::force_low_level_uart_reinit() {
     // Timeout RX court pour vider rapidement
     uart_set_rx_timeout(port, 2);
 
-    // Purger les buffers pour ÃÂ©viter les rÃÂ©sidus
+    // Purger les buffers pour ÃÂÃÂ©viter les rÃÂÃÂ©sidus
     uart_flush_input(port);
     CUSTOM_DELAY(2);
 
@@ -484,6 +484,6 @@ void CN105Climate::force_low_level_uart_reinit() {
     uart_get_baudrate(port, &eff_baud);
     ESP_LOGD(TAG, "UART effective baud=%lu tx_pin=%d rx_pin=%d", (unsigned long)eff_baud, this->tx_pin_, this->rx_pin_);
 #else
-    // Pas dÃ¢ÂÂESP32: rien ÃÂ  faire
+    // Pas dÃÂ¢ÃÂÃÂESP32: rien ÃÂÃÂ  faire
 #endif
 }

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -25,12 +25,12 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
         [this]() -> CN105Climate* { return this; }
     ) {
 
-    // Active les flags de fonctionnalitÃ©s via l'API moderne (Ã©vite les setters dÃ©prÃ©ciÃ©s)
+    // Active les flags de fonctionnalitÃÂ©s via l'API moderne (ÃÂ©vite les setters dÃÂ©prÃÂ©ciÃÂ©s)
     this->traits_.add_feature_flags(
         climate::CLIMATE_SUPPORTS_ACTION |
         climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE
     );
-    // supports_two_point_target_temperature sera dÃ©fini dans setup() selon les modes supportÃ©s
+    // supports_two_point_target_temperature sera dÃÂ©fini dans setup() selon les modes supportÃÂ©s
     this->traits_.set_visual_min_temperature(ESPMHP_MIN_TEMPERATURE);
     this->traits_.set_visual_max_temperature(ESPMHP_MAX_TEMPERATURE);
     this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
@@ -114,14 +114,15 @@ void CN105Climate::registerInfoRequests() {
 
     // Placeholders
     InfoRequest r_error_info("error_info", "Error Info", 0x04, 3, 0);
-    //r_error_info.disabled = true;
+    //r_error_info.onResponse = [this](CN105Climate* self) { self->getErrorInfoFromResponsePacket(); };
+    r_error_info.disabled = (this->error_code_sensor_ == nullptr);
     scheduler_.register_request(r_error_info);
 
     InfoRequest r_timers("timers", "Timers", 0x05, 1, 0);
     r_timers.disabled = true;
     scheduler_.register_request(r_timers);
 
-    // Appel vers la nouvelle mÃ©thode dÃ©diÃ©e
+    // Appel vers la nouvelle mÃÂ©thode dÃÂ©diÃÂ©e
     this->registerHardwareSettingsRequests();
 }
 
@@ -130,14 +131,14 @@ void CN105Climate::registerHardwareSettingsRequests() {
         ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval %u ms", this->hardware_settings_interval_ms_);
         uint32_t interval = this->hardware_settings_interval_ms_;
 
-        // Helper Lambda : VÃ©rifie l'incompatibilitÃ© et dÃ©sactive tout si nÃ©cessaire
+        // Helper Lambda : VÃÂ©rifie l'incompatibilitÃÂ© et dÃÂ©sactive tout si nÃÂ©cessaire
         auto check_and_disable = [](CN105Climate& self, uint8_t code) -> bool {
             if (self.data[0] != code) return false;
 
             bool all_zeros = true;
-            // Sur certaines unitÃ©s (ex: SEZ), les codes peuvent Ãªtre prÃ©sents avec une valeur Ã  0
-            // tant que la session n'est pas en mode installateur. La prÃ©sence de l'octet (code+valeur)
-            // suffit Ã  valider le support.
+            // Sur certaines unitÃÂ©s (ex: SEZ), les codes peuvent ÃÂªtre prÃÂ©sents avec une valeur ÃÂ  0
+            // tant que la session n'est pas en mode installateur. La prÃÂ©sence de l'octet (code+valeur)
+            // suffit ÃÂ  valider le support.
             for (int i = 1; i < self.dataLength; i++) {
                 if (self.data[i] != 0) {
                     all_zeros = false;
@@ -148,7 +149,7 @@ void CN105Climate::registerHardwareSettingsRequests() {
             if (all_zeros) {
                 ESP_LOGW(LOG_FUNCTIONS_TAG, "Response 0x%02X contains only zeros. Feature not supported by unit. Disabling.", code);
 
-                // 1. DÃ©sactiver la requÃªte via le scheduler
+                // 1. DÃÂ©sactiver la requÃÂªte via le scheduler
                 self.scheduler_.disable_request(code);
 
                 // 2. Marquer les composants graphiques comme "Failed" (Unavailable)
@@ -194,8 +195,8 @@ void CN105Climate::registerHardwareSettingsRequests() {
     }
 }
 
-// Les mÃ©thodes sendInfoRequest, markResponseSeenFor, sendNextAfter et processInfoResponse
-// ont Ã©tÃ© dÃ©placÃ©es dans RequestScheduler pour respecter le principe de responsabilitÃ© unique (SRP).
+// Les mÃÂ©thodes sendInfoRequest, markResponseSeenFor, sendNextAfter et processInfoResponse
+// ont ÃÂ©tÃÂ© dÃÂ©placÃÂ©es dans RequestScheduler pour respecter le principe de responsabilitÃÂ© unique (SRP).
 
 
 
@@ -334,11 +335,11 @@ void CN105Climate::setupUART() {
     if (this->parent_->get_data_bits() == 8 &&
         this->parent_->get_parity() == uart::UART_CONFIG_PARITY_EVEN &&
         this->parent_->get_stop_bits() == 1) {
-        ESP_LOGI(LOG_CONN_TAG, "UART configurÃ© en SERIAL_8E1");
+        ESP_LOGI(LOG_CONN_TAG, "UART configurÃÂ© en SERIAL_8E1");
         this->isUARTConnected_ = true;
         this->initBytePointer();
     } else {
-        ESP_LOGW(LOG_CONN_TAG, "UART n'est pas configurÃ© en SERIAL_8E1");
+        ESP_LOGW(LOG_CONN_TAG, "UART n'est pas configurÃÂ© en SERIAL_8E1");
     }
 
 }
@@ -370,8 +371,8 @@ void CN105Climate::reconnectUART() {
     ESP_LOGD(TAG, "reconnectUART()");
     this->lastReconnectTimeMs = CUSTOM_MILLIS;
     this->disconnectUART();
-    // DÃ©sactivÃ©: le fallback UART bas-niveau (ESP-IDF 5.4.x) peut interfÃ©rer avec les
-    // tests de handshake/fallback. On laisse UARTComponent gÃ©rer la rÃ©init standard.
+    // DÃÂ©sactivÃÂ©: le fallback UART bas-niveau (ESP-IDF 5.4.x) peut interfÃÂ©rer avec les
+    // tests de handshake/fallback. On laisse UARTComponent gÃÂ©rer la rÃÂ©init standard.
     this->force_low_level_uart_reinit();
     this->setupUART();
     this->sendFirstConnectionPacket();
@@ -412,8 +413,8 @@ bool CN105Climate::isHeatpumpConnectionActive() {
 
 void CN105Climate::force_low_level_uart_reinit() {
 #ifdef USE_ESP32
-    // RÃ©init basse couche: reconfigurer le contrÃ´leur utilisÃ© par UARTComponent
-    // On utilise le port passÃ© par set_uart_port (fallback UART0 si inconnu)
+    // RÃÂ©init basse couche: reconfigurer le contrÃÂ´leur utilisÃÂ© par UARTComponent
+    // On utilise le port passÃÂ© par set_uart_port (fallback UART0 si inconnu)
     const uart_port_t port = (this->uart_port_ == 1) ? UART_NUM_1 :
 #ifdef UART_NUM_2
     (this->uart_port_ == 2) ? UART_NUM_2 :
@@ -422,13 +423,13 @@ void CN105Climate::force_low_level_uart_reinit() {
 
     ESP_LOGI(TAG, "Forcing low-level UART reinit on port %d (tx=%d, rx=%d)", (int)port, this->tx_pin_, this->rx_pin_);
 
-    // IMPORTANT: ne pas supprimer/rÃ©installer le driver ici pour Ã©viter conflit avec UARTComponent
+    // IMPORTANT: ne pas supprimer/rÃÂ©installer le driver ici pour ÃÂ©viter conflit avec UARTComponent
     // On reconfigure in-place et on assainit les GPIO
     if (this->tx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->tx_pin_);
     if (this->rx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->rx_pin_);
     CUSTOM_DELAY(2);
 
-    // ParamÃ¨tres SERIAL_8E1 @ 2400 bauds (valeurs issues de la config UARTComponent)
+    // ParamÃÂ¨tres SERIAL_8E1 @ 2400 bauds (valeurs issues de la config UARTComponent)
     uart_config_t cfg = {};
     cfg.baud_rate = this->parent_ ? (int)this->parent_->get_baud_rate() : 2400;
     cfg.data_bits = UART_DATA_8_BITS;
@@ -447,7 +448,7 @@ void CN105Climate::force_low_level_uart_reinit() {
         ESP_LOGE(TAG, "uart_set_pin failed: %s", esp_err_to_name(pin_err));
     }
 
-    // RX idle high: assurer un pull-up (utile Ã  bas dÃ©bit/8E1)
+    // RX idle high: assurer un pull-up (utile ÃÂ  bas dÃÂ©bit/8E1)
     if (this->rx_pin_ >= 0) {
         gpio_set_pull_mode((gpio_num_t)this->rx_pin_, GPIO_PULLUP_ONLY);
     }
@@ -455,16 +456,16 @@ void CN105Climate::force_low_level_uart_reinit() {
     // S'assurer du mode UART classique
     uart_set_mode(port, UART_MODE_UART);
 
-    // Attendre que toute TX en cours finisse (si driver dÃ©jÃ  installÃ©)
+    // Attendre que toute TX en cours finisse (si driver dÃÂ©jÃÂ  installÃÂ©)
     uart_wait_tx_done(port, pdMS_TO_TICKS(20));
 
-    // Fixer la source d'horloge UART (bas dÃ©bits peuvent Ãªtre sensibles)
+    // Fixer la source d'horloge UART (bas dÃÂ©bits peuvent ÃÂªtre sensibles)
 #if defined(UART_SCLK_XTAL)
     uart_set_sclk(port, UART_SCLK_XTAL);
 #elif defined(UART_SCLK_APB)
     uart_set_sclk(port, UART_SCLK_APB);
 #endif
-    // Re-forcer explicitement le baud aprÃ¨s sclk
+    // Re-forcer explicitement le baud aprÃÂ¨s sclk
     uart_set_baudrate(port, cfg.baud_rate);
 
     // Assainir inversion/flow control
@@ -474,7 +475,7 @@ void CN105Climate::force_low_level_uart_reinit() {
     // Timeout RX court pour vider rapidement
     uart_set_rx_timeout(port, 2);
 
-    // Purger les buffers pour Ã©viter les rÃ©sidus
+    // Purger les buffers pour ÃÂ©viter les rÃÂ©sidus
     uart_flush_input(port);
     CUSTOM_DELAY(2);
 
@@ -483,6 +484,6 @@ void CN105Climate::force_low_level_uart_reinit() {
     uart_get_baudrate(port, &eff_baud);
     ESP_LOGD(TAG, "UART effective baud=%lu tx_pin=%d rx_pin=%d", (unsigned long)eff_baud, this->tx_pin_, this->rx_pin_);
 #else
-    // Pas dâESP32: rien Ã  faire
+    // Pas dÃ¢ÂÂESP32: rien ÃÂ  faire
 #endif
 }

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -16,6 +16,8 @@
 #include "functions_number.h"
 #include "functions_button.h"
 #include "sub_mode_sensor.h"
+#include "error_code_sensor.h"
+#include "remote_temp_source_info.h"
 #include "hvac_option_switch.h"
 #include "hardware_setting_select.h"
 #include "localization.h"
@@ -86,6 +88,9 @@ namespace esphome {
 
         void set_sub_mode_sensor(esphome::text_sensor::TextSensor* Sub_mode_sensor);
         void set_auto_sub_mode_sensor(esphome::text_sensor::TextSensor* Auto_sub_mode_sensor);
+        void set_error_code_sensor(esphome::text_sensor::TextSensor* error_code_sensor);
+        void set_remote_temp_source(esphome::sensor::Sensor* source);
+        void set_remote_temp_source_info_sensor(esphome::text_sensor::TextSensor* info_sensor);
         void set_hp_uptime_connection_sensor(cn105::HpUpTimeConnectionSensor* hp_up_connection_sensor);
         
         void set_remote_temperature_control_sensor(esphome::binary_sensor::BinarySensor* sensor);
@@ -105,6 +110,9 @@ namespace esphome {
         FunctionsNumber* Functions_set_value_ = nullptr;
         text_sensor::TextSensor* Sub_mode_sensor_ = nullptr;
         text_sensor::TextSensor* Auto_sub_mode_sensor_ = nullptr;
+        text_sensor::TextSensor* error_code_sensor_{ nullptr };
+        sensor::Sensor* remote_temp_source_{ nullptr };
+        text_sensor::TextSensor* remote_temp_source_info_sensor_{ nullptr };
         HVACOptionSwitch* air_purifier_switch_ = nullptr;
         HVACOptionSwitch* night_mode_switch_ = nullptr;
         HVACOptionSwitch* circulator_switch_ = nullptr;
@@ -160,7 +168,7 @@ namespace esphome {
 
 
         float get_setup_priority() const override {
-            return setup_priority::AFTER_WIFI;  // Configurez ce composant après le WiFi
+            return setup_priority::AFTER_WIFI;  // Configurez ce composant aprÃ¨s le WiFi
         }
 
         void generateExtraComponents();
@@ -231,22 +239,22 @@ namespace esphome {
 
         void controlFan();
         void controlSwing();
-        // Bootstrap connexion CN105 en loop() (évite de perdre les tout premiers logs OTA)
+        // Bootstrap connexion CN105 en loop() (Ã©vite de perdre les tout premiers logs OTA)
         void maybe_start_connection_();
 
-        // Délai de grâce configurable avant d'envoyer CONNECT (pour laisser le flux OTA s'attacher)
+        // DÃ©lai de grÃ¢ce configurable avant d'envoyer CONNECT (pour laisser le flux OTA s'attacher)
         void set_connection_bootstrap_delay(uint32_t delay_ms) { this->conn_bootstrap_delay_ms_ = delay_ms; }
 
-        // Mode installateur: utilise un handshake CONNECT étendu (0x5B) au lieu du standard (0x5A)
+        // Mode installateur: utilise un handshake CONNECT Ã©tendu (0x5B) au lieu du standard (0x5A)
         void set_installer_mode(bool mode) {
-            // Mode demandé via YAML
+            // Mode demandÃ© via YAML
             this->installer_mode_ = mode;
-            // Mode effectivement utilisé: peut tomber en fallback vers standard si la PAC ignore 0x5B
+            // Mode effectivement utilisÃ©: peut tomber en fallback vers standard si la PAC ignore 0x5B
             this->installer_mode_effective_ = mode;
             this->installer_mode_fallback_done_ = false;
         }
 
-        // Unité de puissance brute envoyée par la PAC: false = Watts (défaut), true = BTU/s
+        // UnitÃ© de puissance brute envoyÃ©e par la PAC: false = Watts (dÃ©faut), true = BTU/s
         void set_power_unit_is_btu(bool v) { this->power_unit_is_btu_ = v; }
 
         // Configure the climate object with traits that we support.
@@ -412,7 +420,7 @@ namespace esphome {
         wantedHeatpumpRunStates wantedRunStates{};
         cycleManagement loopCycle{};
 
-        // Orchestrateur des requêtes INFO
+        // Orchestrateur des requÃªtes INFO
         RequestScheduler scheduler_;
         void registerInfoRequests();
         void registerHardwareSettingsRequests();
@@ -477,11 +485,11 @@ namespace esphome {
         // Ensure dual setpoints are valid (no NaN, enforce spread in AUTO)
         void sanitizeDualSetpoints();
 
-        // Anti-rebond UI: mémorise le dernier côté modifié et l'instant
+        // Anti-rebond UI: mÃ©morise le dernier cÃ´tÃ© modifiÃ© et l'instant
         uint32_t last_dual_setpoint_change_ms_ = 0;
         char last_dual_setpoint_side_ = 'N'; // 'L' (low), 'H' (high), 'N' (none)
 
-        // Gestion sûre d'un paquet différé à écrire pour éviter la capture d'un buffer de pile
+        // Gestion sÃ»re d'un paquet diffÃ©rÃ© Ã  Ã©crire pour Ã©viter la capture d'un buffer de pile
         void try_write_pending_packet();
         uint8_t pending_packet_[PACKET_LEN] = {};
         int pending_packet_len_ = 0;
@@ -494,12 +502,12 @@ namespace esphome {
         bool conn_wait_logged_ = false;
         bool conn_grace_logged_ = false;
         bool conn_timeout_armed_ = false;
-        uint32_t conn_bootstrap_delay_ms_{ 10000 };  // par défaut 10s
+        uint32_t conn_bootstrap_delay_ms_{ 10000 };  // par dÃ©faut 10s
 
         bool installer_mode_{ false };
         bool installer_mode_effective_{ false };
         bool installer_mode_fallback_done_{ false };
-        bool power_unit_is_btu_{ false };  // true = la PAC envoie en BTU/s (nécessite conversion ×3.412)
+        bool power_unit_is_btu_{ false };  // true = la PAC envoie en BTU/s (nÃ©cessite conversion Ã3.412)
         bool supports_dual_setpoint_ = false;
         int horizontal_vanes_{ 1 }; // Kept for legacy logging if needed, or can be removed if unused.
         VaneType vane_type_{ VaneType::STANDARD };

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -168,7 +168,7 @@ namespace esphome {
 
 
         float get_setup_priority() const override {
-            return setup_priority::AFTER_WIFI;  // Configurez ce composant aprÃ¨s le WiFi
+            return setup_priority::AFTER_WIFI;  // Configurez ce composant aprÃÂ¨s le WiFi
         }
 
         void generateExtraComponents();
@@ -239,22 +239,22 @@ namespace esphome {
 
         void controlFan();
         void controlSwing();
-        // Bootstrap connexion CN105 en loop() (Ã©vite de perdre les tout premiers logs OTA)
+        // Bootstrap connexion CN105 en loop() (ÃÂ©vite de perdre les tout premiers logs OTA)
         void maybe_start_connection_();
 
-        // DÃ©lai de grÃ¢ce configurable avant d'envoyer CONNECT (pour laisser le flux OTA s'attacher)
+        // DÃÂ©lai de grÃÂ¢ce configurable avant d'envoyer CONNECT (pour laisser le flux OTA s'attacher)
         void set_connection_bootstrap_delay(uint32_t delay_ms) { this->conn_bootstrap_delay_ms_ = delay_ms; }
 
-        // Mode installateur: utilise un handshake CONNECT Ã©tendu (0x5B) au lieu du standard (0x5A)
+        // Mode installateur: utilise un handshake CONNECT ÃÂ©tendu (0x5B) au lieu du standard (0x5A)
         void set_installer_mode(bool mode) {
-            // Mode demandÃ© via YAML
+            // Mode demandÃÂ© via YAML
             this->installer_mode_ = mode;
-            // Mode effectivement utilisÃ©: peut tomber en fallback vers standard si la PAC ignore 0x5B
+            // Mode effectivement utilisÃÂ©: peut tomber en fallback vers standard si la PAC ignore 0x5B
             this->installer_mode_effective_ = mode;
             this->installer_mode_fallback_done_ = false;
         }
 
-        // UnitÃ© de puissance brute envoyÃ©e par la PAC: false = Watts (dÃ©faut), true = BTU/s
+        // UnitÃÂ© de puissance brute envoyÃÂ©e par la PAC: false = Watts (dÃÂ©faut), true = BTU/s
         void set_power_unit_is_btu(bool v) { this->power_unit_is_btu_ = v; }
 
         // Configure the climate object with traits that we support.
@@ -317,7 +317,8 @@ namespace esphome {
         void checkHeader(uint8_t inputData);
         void initBytePointer();
         void processDataPacket();
-        void getDataFromResponsePacket();
+        void getErrorInfoFromResponsePacket();
+    void getDataFromResponsePacket();
         void getAutoModeStateFromResponsePacket(); //NET added
         void getPowerFromResponsePacket(); //NET added
         void getSettingsFromResponsePacket();
@@ -420,7 +421,7 @@ namespace esphome {
         wantedHeatpumpRunStates wantedRunStates{};
         cycleManagement loopCycle{};
 
-        // Orchestrateur des requÃªtes INFO
+        // Orchestrateur des requÃÂªtes INFO
         RequestScheduler scheduler_;
         void registerInfoRequests();
         void registerHardwareSettingsRequests();
@@ -485,11 +486,11 @@ namespace esphome {
         // Ensure dual setpoints are valid (no NaN, enforce spread in AUTO)
         void sanitizeDualSetpoints();
 
-        // Anti-rebond UI: mÃ©morise le dernier cÃ´tÃ© modifiÃ© et l'instant
+        // Anti-rebond UI: mÃÂ©morise le dernier cÃÂ´tÃÂ© modifiÃÂ© et l'instant
         uint32_t last_dual_setpoint_change_ms_ = 0;
         char last_dual_setpoint_side_ = 'N'; // 'L' (low), 'H' (high), 'N' (none)
 
-        // Gestion sÃ»re d'un paquet diffÃ©rÃ© Ã  Ã©crire pour Ã©viter la capture d'un buffer de pile
+        // Gestion sÃÂ»re d'un paquet diffÃÂ©rÃÂ© ÃÂ  ÃÂ©crire pour ÃÂ©viter la capture d'un buffer de pile
         void try_write_pending_packet();
         uint8_t pending_packet_[PACKET_LEN] = {};
         int pending_packet_len_ = 0;
@@ -502,12 +503,12 @@ namespace esphome {
         bool conn_wait_logged_ = false;
         bool conn_grace_logged_ = false;
         bool conn_timeout_armed_ = false;
-        uint32_t conn_bootstrap_delay_ms_{ 10000 };  // par dÃ©faut 10s
+        uint32_t conn_bootstrap_delay_ms_{ 10000 };  // par dÃÂ©faut 10s
 
         bool installer_mode_{ false };
         bool installer_mode_effective_{ false };
         bool installer_mode_fallback_done_{ false };
-        bool power_unit_is_btu_{ false };  // true = la PAC envoie en BTU/s (nÃ©cessite conversion Ã3.412)
+        bool power_unit_is_btu_{ false };  // true = la PAC envoie en BTU/s (nÃÂ©cessite conversion ÃÂ3.412)
         bool supports_dual_setpoint_ = false;
         int horizontal_vanes_{ 1 }; // Kept for legacy logging if needed, or can be removed if unused.
         VaneType vane_type_{ VaneType::STANDARD };

--- a/components/cn105/error_code_sensor.h
+++ b/components/cn105/error_code_sensor.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/core/component.h"
+
+
+namespace esphome {
+
+    class ErrorCodeSensor : public text_sensor::TextSensor, public Component {
+    public:
+        ErrorCodeSensor() {}
+    };
+
+}

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -25,7 +25,7 @@ void CN105Climate::set_vertical_vane_select(
 
     this->vertical_vane_select_->setCallbackFunction([this](const char* setting) {
 
-        ESP_LOGD("EVT", "vane.control() -> Demande un chgt de réglage de la vane: %s", setting);
+        ESP_LOGD("EVT", "vane.control() -> Demande un chgt de rÃ©glage de la vane: %s", setting);
 
         this->setVaneSetting(setting);
         this->wantedSettings.hasChanged = true;
@@ -61,7 +61,7 @@ void CN105Climate::set_horizontal_vane_select(
     this->horizontal_vane_select_->traits.set_options(fixedOptions);
 
     this->horizontal_vane_select_->setCallbackFunction([this](const char* setting) {
-        ESP_LOGD("EVT", "wideVane.control() -> Demande un chgt de réglage de la wideVane: %s", setting);
+        ESP_LOGD("EVT", "wideVane.control() -> Demande un chgt de rÃ©glage de la wideVane: %s", setting);
 
         this->setWideVaneSetting(setting);
         this->wantedSettings.hasChanged = true;
@@ -219,6 +219,26 @@ void CN105Climate::set_sub_mode_sensor(esphome::text_sensor::TextSensor* Sub_mod
 
 void CN105Climate::set_auto_sub_mode_sensor(esphome::text_sensor::TextSensor* Auto_sub_mode_sensor) {
     this->Auto_sub_mode_sensor_ = Auto_sub_mode_sensor;
+}
+
+void CN105Climate::set_error_code_sensor(esphome::text_sensor::TextSensor* error_code_sensor) {
+    this->error_code_sensor_ = error_code_sensor;
+}
+
+void CN105Climate::set_remote_temp_source(esphome::sensor::Sensor* source) {
+    this->remote_temp_source_ = source;
+    // Subscribe to source sensor state changes and auto-feed remote temperature
+    source->add_on_state_callback([this](float value) {
+        this->set_remote_temperature(value);
+    });
+}
+
+void CN105Climate::set_remote_temp_source_info_sensor(esphome::text_sensor::TextSensor* info_sensor) {
+    this->remote_temp_source_info_sensor_ = info_sensor;
+    // Publish the source sensor name on next loop
+    if (this->remote_temp_source_ != nullptr) {
+        info_sensor->publish_state(this->remote_temp_source_->get_name());
+    }
 }
 
 void CN105Climate::set_hp_uptime_connection_sensor(cn105::HpUpTimeConnectionSensor* hp_up_connection_sensor) {

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -137,8 +137,8 @@ void CN105Climate::processDataPacket() {
 
     this->hpPacketDebug(this->storedInputData, this->bytesRead + 1, "READ");
 
-    // Pendant le handshake (tant que non connecté), logguer toute trame RX sous CN105_CONN en DEBUG
-    // afin de faciliter le diagnostic (0x7A/0x7B attendus, ou autre réponse inattendue).
+    // Pendant le handshake (tant que non connectÃ©), logguer toute trame RX sous CN105_CONN en DEBUG
+    // afin de faciliter le diagnostic (0x7A/0x7B attendus, ou autre rÃ©ponse inattendue).
     if (!this->isHeatpumpConnected_) {
         ESP_LOGD(LOG_CONN_TAG, "RX during handshake (cmd=0x%02X len=%d)", this->command, this->dataLength);
         this->hpPacketDebug(this->storedInputData, this->bytesRead + 1, LOG_CONN_TAG);
@@ -231,7 +231,7 @@ void CN105Climate::getSettingsFromResponsePacket() {
         receivedSettings.temperature = lookupByteMapValue(TEMP_MAP, TEMP, 16, data[5], "temperature reading");
     }
 
-    ESP_LOGD("Decoder", "[Temp °C: %f]", receivedSettings.temperature);
+    ESP_LOGD("Decoder", "[Temp Â°C: %f]", receivedSettings.temperature);
 
     receivedSettings.fan = lookupByteMapValue(FAN_MAP, FAN, 6, data[6], "fan reading");
     ESP_LOGD("Decoder", "[Fan: %s]", receivedSettings.fan);
@@ -303,10 +303,10 @@ void CN105Climate::getRoomTemperatureFromResponsePacket() {
         int temp = data[6];
         temp -= 128;
         receivedStatus.roomTemperature = temp / 2.0f;
-        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[6]  --> [Room °C: %f]", receivedStatus.roomTemperature);
+        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[6]  --> [Room Â°C: %f]", receivedStatus.roomTemperature);
     } else {
         receivedStatus.roomTemperature = lookupByteMapValue(ROOM_TEMP_MAP, ROOM_TEMP, 32, data[3]);
-        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[3] map --> [Room °C : %f]", receivedStatus.roomTemperature);
+        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[3] map --> [Room Â°C : %f]", receivedStatus.roomTemperature);
     }
 
     // Update the remote temperature control sensor (Issue 290)
@@ -323,8 +323,8 @@ void CN105Climate::getRoomTemperatureFromResponsePacket() {
 
     receivedStatus.runtimeHours = float((data[11] << 16) | (data[12] << 8) | data[13]) / 60;
 
-    ESP_LOGD("Decoder", "[Room °C: %f]", receivedStatus.roomTemperature);
-    ESP_LOGD("Decoder", "[OAT  °C: %f]", receivedStatus.outsideAirTemperature);
+    ESP_LOGD("Decoder", "[Room Â°C: %f]", receivedStatus.roomTemperature);
+    ESP_LOGD("Decoder", "[OAT  Â°C: %f]", receivedStatus.outsideAirTemperature);
 
     // no change with this packet to currentStatus for operating and compressorFrequency
     receivedStatus.operating = currentStatus.operating;
@@ -425,14 +425,25 @@ void CN105Climate::getDataFromResponsePacket() {
     if (this->scheduler_.process_response(code)) {
         return;
     }
-    // Sinon, switch pour les cas non gérés par l'orchestrateur
+    // Sinon, switch pour les cas non gÃ©rÃ©s par l'orchestrateur
     switch (code) {
 
-    case 0x04:
-        /* unknown */
-        ESP_LOGI("Decoder", "[0x04 is unknown : not implemented]");
-        //this->last_received_packet_sensor->publish_state("0x62-> 0x04: Data -> Unknown");
+    case 0x04: {
+        /* Error info */
+        ESP_LOGD("Decoder", "[0x04 error info]");
+        if (this->error_code_sensor_ != nullptr) {
+            uint8_t error_raw = data[4];
+            uint8_t error_sub = data[5];
+            if (error_raw == 0x00 && error_sub == 0x00) {
+                this->error_code_sensor_->publish_state("No Error");
+            } else {
+                char buf[32];
+                snprintf(buf, sizeof(buf), "Error 0x%02X (sub 0x%02X)", error_raw, error_sub);
+                this->error_code_sensor_->publish_state(buf);
+            }
+        }
         break;
+    }
 
     case 0x05:
         /* timer packet */
@@ -492,12 +503,12 @@ void CN105Climate::processCommand() {
         this->updateSuccess();
         break;
 
-    case 0x62:  /* packet contains data (room °C, settings, timer, status, or functions...)*/
+    case 0x62:  /* packet contains data (room Â°C, settings, timer, status, or functions...)*/
         this->getDataFromResponsePacket();
         break;
     case 0x7a:  // Connection success (User / standard)
     case 0x7b:  // Connection success (Installer / extended)
-        // Log en INFO sur le tag dédié, détails en DEBUG via hpPacketDebug
+        // Log en INFO sur le tag dÃ©diÃ©, dÃ©tails en DEBUG via hpPacketDebug
         ESP_LOGI(LOG_CONN_TAG, "--> Heatpump did reply: connection success (%s, 0x%02X)! <--",
             (this->command == 0x7b) ? "Installer" : "User",
             this->command);

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -137,8 +137,8 @@ void CN105Climate::processDataPacket() {
 
     this->hpPacketDebug(this->storedInputData, this->bytesRead + 1, "READ");
 
-    // Pendant le handshake (tant que non connectÃ©), logguer toute trame RX sous CN105_CONN en DEBUG
-    // afin de faciliter le diagnostic (0x7A/0x7B attendus, ou autre rÃ©ponse inattendue).
+    // Pendant le handshake (tant que non connectÃÂ©), logguer toute trame RX sous CN105_CONN en DEBUG
+    // afin de faciliter le diagnostic (0x7A/0x7B attendus, ou autre rÃÂ©ponse inattendue).
     if (!this->isHeatpumpConnected_) {
         ESP_LOGD(LOG_CONN_TAG, "RX during handshake (cmd=0x%02X len=%d)", this->command, this->dataLength);
         this->hpPacketDebug(this->storedInputData, this->bytesRead + 1, LOG_CONN_TAG);
@@ -231,7 +231,7 @@ void CN105Climate::getSettingsFromResponsePacket() {
         receivedSettings.temperature = lookupByteMapValue(TEMP_MAP, TEMP, 16, data[5], "temperature reading");
     }
 
-    ESP_LOGD("Decoder", "[Temp Â°C: %f]", receivedSettings.temperature);
+    ESP_LOGD("Decoder", "[Temp ÃÂ°C: %f]", receivedSettings.temperature);
 
     receivedSettings.fan = lookupByteMapValue(FAN_MAP, FAN, 6, data[6], "fan reading");
     ESP_LOGD("Decoder", "[Fan: %s]", receivedSettings.fan);
@@ -303,10 +303,10 @@ void CN105Climate::getRoomTemperatureFromResponsePacket() {
         int temp = data[6];
         temp -= 128;
         receivedStatus.roomTemperature = temp / 2.0f;
-        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[6]  --> [Room Â°C: %f]", receivedStatus.roomTemperature);
+        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[6]  --> [Room ÃÂ°C: %f]", receivedStatus.roomTemperature);
     } else {
         receivedStatus.roomTemperature = lookupByteMapValue(ROOM_TEMP_MAP, ROOM_TEMP, 32, data[3]);
-        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[3] map --> [Room Â°C : %f]", receivedStatus.roomTemperature);
+        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[3] map --> [Room ÃÂ°C : %f]", receivedStatus.roomTemperature);
     }
 
     // Update the remote temperature control sensor (Issue 290)
@@ -323,8 +323,8 @@ void CN105Climate::getRoomTemperatureFromResponsePacket() {
 
     receivedStatus.runtimeHours = float((data[11] << 16) | (data[12] << 8) | data[13]) / 60;
 
-    ESP_LOGD("Decoder", "[Room Â°C: %f]", receivedStatus.roomTemperature);
-    ESP_LOGD("Decoder", "[OAT  Â°C: %f]", receivedStatus.outsideAirTemperature);
+    ESP_LOGD("Decoder", "[Room ÃÂ°C: %f]", receivedStatus.roomTemperature);
+    ESP_LOGD("Decoder", "[OAT  ÃÂ°C: %f]", receivedStatus.outsideAirTemperature);
 
     // no change with this packet to currentStatus for operating and compressorFrequency
     receivedStatus.operating = currentStatus.operating;
@@ -418,6 +418,21 @@ void CN105Climate::terminateCycle() {
 
     this->nbCompleteCycles_++;
 }
+void CN105Climate::getErrorInfoFromResponsePacket() {
+    ESP_LOGD("Decoder", "0x04 error info");
+    if (this->error_code_sensor_ != nullptr) {
+        uint8_t error_raw = this->data[4];
+        uint8_t error_sub = this->data[5];
+        if (error_raw == 0x00 && error_sub == 0x00) {
+            this->error_code_sensor_->publish_state("No Error");
+        } else {
+            char buf[32];
+            snprintf(buf, sizeof(buf), "Error 0x%02X sub 0x%02X", error_raw, error_sub);
+            this->error_code_sensor_->publish_state(buf);
+        }
+    }
+}
+
 void CN105Climate::getDataFromResponsePacket() {
 
     // D'abord, laissons l'orchestrateur traiter les codes connus
@@ -425,24 +440,13 @@ void CN105Climate::getDataFromResponsePacket() {
     if (this->scheduler_.process_response(code)) {
         return;
     }
-    // Sinon, switch pour les cas non gÃ©rÃ©s par l'orchestrateur
+    // Sinon, switch pour les cas non gÃÂ©rÃÂ©s par l'orchestrateur
     switch (code) {
 
     case 0x04: {
-        /* Error info */
-        ESP_LOGD("Decoder", "[0x04 error info]");
-        if (this->error_code_sensor_ != nullptr) {
-            uint8_t error_raw = data[4];
-            uint8_t error_sub = data[5];
-            if (error_raw == 0x00 && error_sub == 0x00) {
-                this->error_code_sensor_->publish_state("No Error");
-            } else {
-                char buf[32];
-                snprintf(buf, sizeof(buf), "Error 0x%02X (sub 0x%02X)", error_raw, error_sub);
-                this->error_code_sensor_->publish_state(buf);
-            }
-        }
-        break;
+            // Error info - handled by getErrorInfoFromResponsePacket
+            this->getErrorInfoFromResponsePacket();
+            break;
     }
 
     case 0x05:
@@ -503,12 +507,12 @@ void CN105Climate::processCommand() {
         this->updateSuccess();
         break;
 
-    case 0x62:  /* packet contains data (room Â°C, settings, timer, status, or functions...)*/
+    case 0x62:  /* packet contains data (room ÃÂ°C, settings, timer, status, or functions...)*/
         this->getDataFromResponsePacket();
         break;
     case 0x7a:  // Connection success (User / standard)
     case 0x7b:  // Connection success (Installer / extended)
-        // Log en INFO sur le tag dÃ©diÃ©, dÃ©tails en DEBUG via hpPacketDebug
+        // Log en INFO sur le tag dÃÂ©diÃÂ©, dÃÂ©tails en DEBUG via hpPacketDebug
         ESP_LOGI(LOG_CONN_TAG, "--> Heatpump did reply: connection success (%s, 0x%02X)! <--",
             (this->command == 0x7b) ? "Installer" : "User",
             this->command);

--- a/components/cn105/remote_temp_source_info.h
+++ b/components/cn105/remote_temp_source_info.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/core/component.h"
+
+
+namespace esphome {
+
+    class RemoteTempSourceInfo : public text_sensor::TextSensor, public Component {
+    public:
+        RemoteTempSourceInfo() {}
+    };
+
+}


### PR DESCRIPTION
## Summary

Adds two new features to the CN105 ESPHome component:

### 1. Error Code Sensor (0x04 packet)
- New `error_code_sensor` (text sensor) that polls and decodes the 0x04 error info packet
- Publishes `"No Error"` when clear, or the raw error/sub-code (e.g. `"Error 0x80 (sub 0x01)"`)
- Renames the previously unused `r_unknown` to `r_error_info` and increases poll priority

### 2. Remote Temperature Source Info
- New `remote_temperature_source` config option that accepts a sensor ID reference
- Automatically subscribes to the source sensor and feeds values to `set_remote_temperature()` — no manual lambda needed
- Optional `remote_temperature_source_info` text sensor publishes the source sensor’s name for visibility in HA

## Usage

```yaml
climate:
  - platform: cn105
    # Error code sensor
    error_code_sensor:
      name: "HVAC Error Code"
    # Remote temp source (replaces manual lambda)
    remote_temperature_source:
      sensor_id: greatroom_temperature
      remote_temperature_source_info:
        name: "HVAC Remote Temp Source"
```

## Files Changed

| File | Change |
|------|--------|
| `error_code_sensor.h` | New ErrorCodeSensor TextSensor subclass |
| `remote_temp_source_info.h` | New RemoteTempSourceInfo TextSensor subclass |
| `climate.py` | Config options, schemas, and codegen for both features |
| `cn105.h` | Setter declarations and member variables |
| `cn105.cpp` | Rename r_unknown → r_error_info, increase priority |
| `hp_readings.cpp` | Implement case 0x04 error info decoding |
| `extraComponents.cpp` | Setter implementations with auto-subscribe logic |
