### PR TITLE
fix: display remote sensor temp in HA climate entity when active (fixes #619)

### DIFF
--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -544,7 +544,12 @@ void CN105Climate::statusChanged(heatpumpStatus status) {
         this->currentStatus.runtimeHours = status.runtimeHours;
         this->currentStatus.roomTemperature = status.roomTemperature;
         this->currentStatus.outsideAirTemperature = status.outsideAirTemperature;
-        this->setCurrentTemperature(this->currentStatus.roomTemperature);
+        // If a remote temperature sensor is active, display that value in HA
+        // instead of the HP internal intake sensor (fix: PR #619)
+        float displayTemperature = (this->remoteTemperature_ > 0)
+            ? this->remoteTemperature_
+            : this->currentStatus.roomTemperature;
+        this->setCurrentTemperature(displayTemperature);
 
         this->updateAction();       // update action info on HA climate component
         this->publish_state();

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -11,7 +11,7 @@ void esphome::log_info_uint32(const char* tag, const char* msg, uint32_t value, 
 #else
     ESP_LOGI(tag, "%s %u %s", msg, (unsigned int)value, suffix);
 #endif
-}
+
 void esphome::log_debug_uint32(const char* tag, const char* msg, uint32_t value, const char* suffix) {
 #if __GNUC__ >= 11
     ESP_LOGD(tag, "%s %lu %s", msg, (unsigned long)value, suffix);
@@ -238,7 +238,12 @@ void CN105Climate::setTargetTemperatureHigh(float temperature) {
 }
 
 void CN105Climate::setCurrentTemperature(float temperature) {
-    this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(temperature);
+    // If a remote temperature sensor is active, display that value in HA instead of the HP internal sensor
+    if (this->remoteTemperature_ > 0) {
+        this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(this->remoteTemperature_);
+    } else {
+        this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(temperature);
+    }
 }
 
 void CN105Climate::sanitizeDualSetpoints() {

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -11,7 +11,7 @@ void esphome::log_info_uint32(const char* tag, const char* msg, uint32_t value, 
 #else
     ESP_LOGI(tag, "%s %u %s", msg, (unsigned int)value, suffix);
 #endif
-
+}
 void esphome::log_debug_uint32(const char* tag, const char* msg, uint32_t value, const char* suffix) {
 #if __GNUC__ >= 11
     ESP_LOGD(tag, "%s %lu %s", msg, (unsigned long)value, suffix);
@@ -238,12 +238,7 @@ void CN105Climate::setTargetTemperatureHigh(float temperature) {
 }
 
 void CN105Climate::setCurrentTemperature(float temperature) {
-    // If a remote temperature sensor is active, display that value in HA instead of the HP internal sensor
-    if (this->remoteTemperature_ > 0) {
-        this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(this->remoteTemperature_);
-    } else {
-        this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(temperature);
-    }
+    this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(temperature);
 }
 
 void CN105Climate::sanitizeDualSetpoints() {


### PR DESCRIPTION
## Context

This PR integrates and corrects the changes proposed in #619 by @calvindomenico.

The original PR identified a real bug: when `set_remote_temperature()` is configured, the HA climate entity continues to display the heat pump's internal intake sensor temperature instead of the remote sensor value, because `setCurrentTemperature()` always uses raw HP data.

## Issues with the original PR

The original commit (`7a33e0a`) had two problems that prevented it from compiling:

### 1. 🐛 Missing closing brace (compilation error)
The closing `}` of `log_info_uint32()` was accidentally deleted, causing the function body to bleed into `log_debug_uint32()`:
```cpp
// BROKEN (PR #619):
void esphome::log_info_uint32(...) {
#endif
            // <- missing `}` here !
void esphome::log_debug_uint32(...) {  // ← nested definition → compile error
```

### 2. ⚙️ Suboptimal fix placement
The `remoteTemperature_` override logic was added inside the low-level `setCurrentTemperature()` setter, which is called from multiple contexts. The correct single call-site is `statusChanged()` in `hp_readings.cpp`, which is the only function responsible for updating the temperature displayed in HA from HP readings.

## Changes

- **`utils.cpp`**: Restore the missing `}` on `log_info_uint32()`; revert `setCurrentTemperature()` to its clean, single-responsibility form.
- **`hp_readings.cpp`**: Apply the remote temperature display logic in `statusChanged()`, the correct call-site:

```cpp
// When a remote temperature sensor is active, use it for HA display
// instead of the HP internal intake sensor
float displayTemperature = (this->remoteTemperature_ > 0)
    ? this->remoteTemperature_
    : this->currentStatus.roomTemperature;
this->setCurrentTemperature(displayTemperature);
```

## Behaviour

| Condition | `current_temperature` shown in HA |
|---|---|
| No remote sensor configured | HP internal room temperature (unchanged) |
| `set_remote_temperature(T)` active | Remote sensor value `T` |
| `set_remote_temperature(0)` (timeout) | Falls back to HP internal sensor |

Closes #619