### PR TITLE
Prevent packet collision between cycle packets and keep-alive packet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@ DIAGNOSTIC-DUAL-SETPOINT.md
 DIFF-MODIFICATIONS.md
 RESUME-CORRECTIONS.md
 snapshot.sh
-.vscode/*
-.vscode/settings.json
+**/.vscode/*
 hp-esp32-arduino.yaml
 hp-esp32-c6-esp-idf.yaml
 hp-esp32-s2-saola-arduino.yaml

--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -709,6 +709,9 @@ void CN105Climate::set_remote_temperature(float setting) {
     this->shouldSendExternalTemperature_ = true;
     ESP_LOGD(LOG_REMOTE_TEMP, "setting remote temperature to %f", this->remoteTemperature_);
 
+    // Reset the watchdog timeout (HA sent us a fresh value)
+    this->pingExternalTemperature();
+
     // Manage keep-alive timer based on temperature value
     if (setting > 0) {
         // Start keep-alive if not already running (periodic re-send like Kumo does)

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -269,7 +269,7 @@ void CN105Climate::startRemoteTempKeepAlive() {
             ESP_LOGD(LOG_REMOTE_TEMP, "Keep-alive: re-sending remote temperature %.1f", this->remoteTemperature_);
             // Send the temperature packet without resetting the watchdog timeout
             // (watchdog is only reset when HA sends a new value via set_remote_temperature)
-            this->sendRemoteTemperaturePacket();
+            this->shouldSendExternalTemperature_ = true;
         } else {
             if (!this->isHeatpumpConnected_) {
                 ESP_LOGW(LOG_REMOTE_TEMP, "Keep-alive skipped: Heatpump not connected!");

--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -552,9 +552,6 @@ void CN105Climate::sendRemoteTemperature() {
 
     // Send the packet
     this->sendRemoteTemperaturePacket();
-
-    // Reset the watchdog timeout (HA sent us a fresh value)
-    this->pingExternalTemperature();
 }
 
 void CN105Climate::sendWantedRunStates() {


### PR DESCRIPTION
After updating to commit 1257bce I started having sporadic jumps in my heat pump remote temp. Parsing the log messages, they seemed to line up with collisions between the keep-alive packets and cycle packets. Changing the keep-alive packets to send at the end of the next cycle resolves the issues. This will introduce additional delays in the keep-alive packets of up to the cycle update interval, but that shouldn't do any harm if the timeouts are setup well.