### PR TITLE
Prevent packet collision between cycle packets and function set/get packets

### DIFF
--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -13,24 +13,24 @@ using namespace esphome;
 CN105Climate::CN105Climate(uart::UARTComponent* uart) :
     UARTDevice(uart),
     scheduler_(
-        // send_callback: envoie un paquet via buildAndSendInfoPacket
+        // send callback: send a packet via buildAndSendInfoPacket
         [this](uint8_t code) { this->buildAndSendInfoPacket(code); },
-        // timeout_callback: utilise set_timeout de Component
+        // timeout_callback: uses set_timeout from component
         [this](const std::string& name, uint32_t timeout_ms, std::function<void()> callback) {
             this->set_timeout(name.c_str(), timeout_ms, std::move(callback));
         },
-        // terminate_callback: termine le cycle
+        // terminate_callback: completes the cycle
         [this]() { this->terminateCycle(); },
-        // context_callback: retourne this pour les callbacks canSend et onResponse
+        // context_callback: Returns 'this' for the 'canSend' and 'onResponse' callbacks.
         [this]() -> CN105Climate* { return this; }
     ) {
 
-    // Active les flags de fonctionnalitÃÂÃÂÃÂÃÂ©s via l'API moderne (ÃÂÃÂÃÂÃÂ©vite les setters dÃÂÃÂÃÂÃÂ©prÃÂÃÂÃÂÃÂ©ciÃÂÃÂÃÂÃÂ©s)
+    // Enables feature flags via the modern API (avoids deprecated setters).
     this->traits_.add_feature_flags(
         climate::CLIMATE_SUPPORTS_ACTION |
         climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE
     );
-    // supports_two_point_target_temperature sera dÃÂÃÂÃÂÃÂ©fini dans setup() selon les modes supportÃÂÃÂÃÂÃÂ©s
+    // supports_two_point_target_temperature will be defined in setup() depending on the supported modes
     this->traits_.set_visual_min_temperature(ESPMHP_MIN_TEMPERATURE);
     this->traits_.set_visual_max_temperature(ESPMHP_MAX_TEMPERATURE);
     this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
@@ -121,81 +121,98 @@ void CN105Climate::registerInfoRequests() {
     r_timers.disabled = true;
     scheduler_.register_request(r_timers);
 
-    // Appel vers la nouvelle mÃÂÃÂÃÂÃÂ©thode dÃÂÃÂÃÂÃÂ©diÃÂÃÂÃÂÃÂ©e
+    // Call to the new dedicated method.
     this->registerHardwareSettingsRequests();
 }
 
 void CN105Climate::registerHardwareSettingsRequests() {
+    uint32_t interval = 0;
+    bool is_enabled = false;
+
     if (!this->hardware_settings_.empty()) {
         ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval %u ms", this->hardware_settings_interval_ms_);
-        uint32_t interval = this->hardware_settings_interval_ms_;
-
-        // Helper Lambda : VÃÂÃÂÃÂÃÂ©rifie l'incompatibilitÃÂÃÂÃÂÃÂ© et dÃÂÃÂÃÂÃÂ©sactive tout si nÃÂÃÂÃÂÃÂ©cessaire
-        auto check_and_disable = [](CN105Climate& self, uint8_t code) -> bool {
-            if (self.data[0] != code) return false;
-
-            bool all_zeros = true;
-            // Sur certaines unitÃÂÃÂÃÂÃÂ©s (ex: SEZ), les codes peuvent ÃÂÃÂÃÂÃÂªtre prÃÂÃÂÃÂÃÂ©sents avec une valeur ÃÂÃÂÃÂÃÂ  0
-            // tant que la session n'est pas en mode installateur. La prÃÂÃÂÃÂÃÂ©sence de l'octet (code+valeur)
-            // suffit ÃÂÃÂÃÂÃÂ  valider le support.
-            for (int i = 1; i < self.dataLength; i++) {
-                if (self.data[i] != 0) {
-                    all_zeros = false;
-                    break;
-                }
-            }
-
-            if (all_zeros) {
-                ESP_LOGW(LOG_FUNCTIONS_TAG, "Response 0x%02X contains only zeros. Feature not supported by unit. Disabling.", code);
-
-                // 1. DÃÂÃÂÃÂÃÂ©sactiver la requÃÂÃÂÃÂÃÂªte via le scheduler
-                self.scheduler_.disable_request(code);
-
-                // 2. Marquer les composants graphiques comme "Failed" (Unavailable)
-                ESP_LOGD(LOG_FUNCTIONS_TAG, "Marking Hardware Setting Selects as failed.");
-                for (auto* setting : self.hardware_settings_) {
-                    setting->set_enabled(false);
-                }
-
-                return false;
-            }
-            return true;
-            };
-
-        // --- Part 1 (0x20) ---
-        InfoRequest r_funcs1("functions1", "Functions Part 1", 0x20, 3, 0, interval, LOG_FUNCTIONS_TAG);
-        r_funcs1.onResponse = [this, check_and_disable](CN105Climate& self) {
-            // Log the raw packet and decoded pairs even if the unit returns all zeros
-            self.hpPacketDebug(self.data, self.dataLength, "RX 0x20");
-            self.hpFunctionsDebug(self.data, self.dataLength);
-            if (check_and_disable(self, 0x20)) {
-                self.functions.setData1(&self.data[1]);
-                ESP_LOGD(LOG_FUNCTIONS_TAG, "Got functions packet 1 (via InfoRequest)");
-            }
-            };
-        scheduler_.register_request(r_funcs1);
-
-        // --- Part 2 (0x22) ---
-        InfoRequest r_funcs2("functions2", "Functions Part 2", 0x22, 3, 0, interval, LOG_FUNCTIONS_TAG);
-        r_funcs2.onResponse = [this, check_and_disable](CN105Climate& self) {
-            // Log the raw packet and decoded pairs even if the unit returns all zeros
-            self.hpPacketDebug(self.data, self.dataLength, "RX 0x22");
-            self.hpFunctionsDebug(self.data, self.dataLength);
-            if (check_and_disable(self, 0x22)) {
-                self.functions.setData2(&self.data[1]);
-                ESP_LOGD(LOG_FUNCTIONS_TAG, "Got functions packet 2 (via InfoRequest)");
-                self.functionsArrived();
-            }
-            };
-        scheduler_.register_request(r_funcs2);
-
-    } else {
-        ESP_LOGD(LOG_FUNCTIONS_TAG, "No hardware settings configured in YAML, skipping 0x20/0x22 requests");
+        interval = this->hardware_settings_interval_ms_;
+        is_enabled = true;
     }
+    else {
+        ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22), disabled");
+    }
+
+    // Helper Lambda: Checks for incompatibility and disables everything if necessary.
+    auto check_and_disable = [](CN105Climate& self, uint8_t code) -> bool {
+        if (self.data[0] != code) return false;
+
+        bool all_zeros = true;
+        // On some units (e.g. SEZ), codes may be present with a value of zero as long as the session
+        // is not in installer mode. The presence of the byte (code+value) just validate the support.
+        for (int i = 1; i < self.dataLength; i++) {
+            if (self.data[i] != 0) {
+                all_zeros = false;
+                break;
+            }
+        }
+
+        if (all_zeros) {
+            ESP_LOGW(LOG_FUNCTIONS_TAG, "Response 0x%02X contains only zeros. Feature not supported by unit. Disabling.", code);
+
+            // 1. Do activate the request via the scheduler.
+            self.scheduler_.disable_request(code);
+
+            // 2. Mark graphics components as failed (unavailable).
+            ESP_LOGD(LOG_FUNCTIONS_TAG, "Marking Hardware Setting Selects as failed.");
+            for (auto* setting : self.hardware_settings_) {
+                setting->set_enabled(false);
+            }
+
+            return false;
+        }
+
+        // If no hardware settings are defined in YAML this was a manual request
+        // that is expected to run once, disable future requests.
+        if (self.hardware_settings_.empty()) {
+            self.scheduler_.disable_request(code);
+        }
+
+        return true;
+        };
+
+    // --- Part 1 (0x20) ---
+    InfoRequest r_funcs1("functions1", "Functions Part 1", 0x20, 3, 0, interval, LOG_FUNCTIONS_TAG);
+    r_funcs1.onResponse = [this, check_and_disable](CN105Climate& self) {
+        // Log the raw packet and decoded pairs even if the unit returns all zeros
+        self.hpPacketDebug(self.data, self.dataLength, "RX 0x20");
+        self.hpFunctionsDebug(self.data, self.dataLength);
+        if (check_and_disable(self, 0x20)) {
+            self.functions.setData1(&self.data[1]);
+            ESP_LOGD(LOG_FUNCTIONS_TAG, "Got functions packet 1 (via InfoRequest)");
+        }
+        };
+    scheduler_.register_request(r_funcs1);
+    if (!is_enabled) {
+        scheduler_.disable_request(0x20);
+    }
+
+    // --- Part 2 (0x22) ---
+    InfoRequest r_funcs2("functions2", "Functions Part 2", 0x22, 3, 0, interval, LOG_FUNCTIONS_TAG);
+    r_funcs2.onResponse = [this, check_and_disable](CN105Climate& self) {
+        // Log the raw packet and decoded pairs even if the unit returns all zeros
+        self.hpPacketDebug(self.data, self.dataLength, "RX 0x22");
+        self.hpFunctionsDebug(self.data, self.dataLength);
+        if (check_and_disable(self, 0x22)) {
+            self.functions.setData2(&self.data[1]);
+            ESP_LOGD(LOG_FUNCTIONS_TAG, "Got functions packet 2 (via InfoRequest)");
+            self.functionsArrived();
+        }
+        };
+    scheduler_.register_request(r_funcs2);
+    if (!is_enabled) {
+        scheduler_.disable_request(0x22);
+    }
+
 }
 
-// Les mÃÂÃÂÃÂÃÂ©thodes sendInfoRequest, markResponseSeenFor, sendNextAfter et processInfoResponse
-// ont ÃÂÃÂÃÂÃÂ©tÃÂÃÂÃÂÃÂ© dÃÂÃÂÃÂÃÂ©placÃÂÃÂÃÂÃÂ©es dans RequestScheduler pour respecter le principe de responsabilitÃÂÃÂÃÂÃÂ© unique (SRP).
+// The sendInfoRequest, markResponseSeenFor, sendNextAfter, and processInfoResponse methods
+// have been placed in RequestScheduler to comply with the Single Responsibility Principle (SRP).
 
 
 
@@ -370,8 +387,8 @@ void CN105Climate::reconnectUART() {
     ESP_LOGD(TAG, "reconnectUART()");
     this->lastReconnectTimeMs = CUSTOM_MILLIS;
     this->disconnectUART();
-    // DÃÂÃÂÃÂÃÂ©sactivÃÂÃÂÃÂÃÂ©: le fallback UART bas-niveau (ESP-IDF 5.4.x) peut interfÃÂÃÂÃÂÃÂ©rer avec les
-    // tests de handshake/fallback. On laisse UARTComponent gÃÂÃÂÃÂÃÂ©rer la rÃÂÃÂÃÂÃÂ©init standard.
+    // Disabled: Low-level UART fallback (ESP-IDF 5.4.x) can interfere with the
+    // handshake/fallback tests. We let UARTComponent generate the standard reset.
     this->force_low_level_uart_reinit();
     this->setupUART();
     this->sendFirstConnectionPacket();
@@ -412,8 +429,8 @@ bool CN105Climate::isHeatpumpConnectionActive() {
 
 void CN105Climate::force_low_level_uart_reinit() {
 #ifdef USE_ESP32
-    // RÃÂÃÂÃÂÃÂ©init basse couche: reconfigurer le contrÃÂÃÂÃÂÃÂ´leur utilisÃÂÃÂÃÂÃÂ© par UARTComponent
-    // On utilise le port passÃÂÃÂÃÂÃÂ© par set_uart_port (fallback UART0 si inconnu)
+    // Low layer reset: reconfigure user control by UARTComponent
+    // We use the port passed by set_uart_port (fallback UART0 if unknown)
     const uart_port_t port = (this->uart_port_ == 1) ? UART_NUM_1 :
 #ifdef UART_NUM_2
     (this->uart_port_ == 2) ? UART_NUM_2 :
@@ -422,13 +439,13 @@ void CN105Climate::force_low_level_uart_reinit() {
 
     ESP_LOGI(TAG, "Forcing low-level UART reinit on port %d (tx=%d, rx=%d)", (int)port, this->tx_pin_, this->rx_pin_);
 
-    // IMPORTANT: ne pas supprimer/rÃÂÃÂÃÂÃÂ©installer le driver ici pour ÃÂÃÂÃÂÃÂ©viter conflit avec UARTComponent
-    // On reconfigure in-place et on assainit les GPIO
+    // IMPORTANT: do not delete/reinstall the driver here to avoid conflict with UARTComponent
+    // We reconfigure in-place and sanitize the GPIOs
     if (this->tx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->tx_pin_);
     if (this->rx_pin_ >= 0) gpio_reset_pin((gpio_num_t)this->rx_pin_);
     CUSTOM_DELAY(2);
 
-    // ParamÃÂÃÂÃÂÃÂ¨tres SERIAL_8E1 @ 2400 bauds (valeurs issues de la config UARTComponent)
+    // Settings SERIAL_8E1 @ 2400 bauds (values ​​from the UARTComponent config)
     uart_config_t cfg = {};
     cfg.baud_rate = this->parent_ ? (int)this->parent_->get_baud_rate() : 2400;
     cfg.data_bits = UART_DATA_8_BITS;
@@ -439,7 +456,7 @@ void CN105Climate::force_low_level_uart_reinit() {
 
     uart_param_config(port, &cfg);
 
-    // Reconfigurer les pins si connues; sinon GPIO1/2 (Atom S3 yaml)
+    // Reconfigure the pins if known; otherwise GPIO1/2 (Atom S3 yaml)
     int tx = (this->tx_pin_ >= 0) ? this->tx_pin_ : 1;
     int rx = (this->rx_pin_ >= 0) ? this->rx_pin_ : 2;
     esp_err_t pin_err = uart_set_pin(port, (gpio_num_t)tx, (gpio_num_t)rx, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
@@ -447,34 +464,34 @@ void CN105Climate::force_low_level_uart_reinit() {
         ESP_LOGE(TAG, "uart_set_pin failed: %s", esp_err_to_name(pin_err));
     }
 
-    // RX idle high: assurer un pull-up (utile ÃÂÃÂÃÂÃÂ  bas dÃÂÃÂÃÂÃÂ©bit/8E1)
+    // RX idle high: ensure a pull-up (useful at low bitrates/8E1)
     if (this->rx_pin_ >= 0) {
         gpio_set_pull_mode((gpio_num_t)this->rx_pin_, GPIO_PULLUP_ONLY);
     }
 
-    // S'assurer du mode UART classique
+    // Ensure classic UART mode
     uart_set_mode(port, UART_MODE_UART);
 
-    // Attendre que toute TX en cours finisse (si driver dÃÂÃÂÃÂÃÂ©jÃÂÃÂÃÂÃÂ  installÃÂÃÂÃÂÃÂ©)
+    // Wait for any TX in progress to finish (if driver already installed)
     uart_wait_tx_done(port, pdMS_TO_TICKS(20));
 
-    // Fixer la source d'horloge UART (bas dÃÂÃÂÃÂÃÂ©bits peuvent ÃÂÃÂÃÂÃÂªtre sensibles)
+    // Fix UART clock source (lower bits may be sensitive)
 #if defined(UART_SCLK_XTAL)
     uart_set_sclk(port, UART_SCLK_XTAL);
 #elif defined(UART_SCLK_APB)
     uart_set_sclk(port, UART_SCLK_APB);
 #endif
-    // Re-forcer explicitement le baud aprÃÂÃÂÃÂÃÂ¨s sclk
+    // Explicitly re-force baud after sclk
     uart_set_baudrate(port, cfg.baud_rate);
 
-    // Assainir inversion/flow control
+    // Disable inversion/flow control
     uart_set_line_inverse(port, UART_SIGNAL_INV_DISABLE);
     uart_set_hw_flow_ctrl(port, UART_HW_FLOWCTRL_DISABLE, 0);
 
-    // Timeout RX court pour vider rapidement
+    // Short RX timeout for quick emptying
     uart_set_rx_timeout(port, 2);
 
-    // Purger les buffers pour ÃÂÃÂÃÂÃÂ©viter les rÃÂÃÂÃÂÃÂ©sidus
+    // Purge buffers to avoid residue
     uart_flush_input(port);
     CUSTOM_DELAY(2);
 
@@ -483,6 +500,6 @@ void CN105Climate::force_low_level_uart_reinit() {
     uart_get_baudrate(port, &eff_baud);
     ESP_LOGD(TAG, "UART effective baud=%lu tx_pin=%d rx_pin=%d", (unsigned long)eff_baud, this->tx_pin_, this->rx_pin_);
 #else
-    // Pas dÃÂÃÂ¢ÃÂÃÂÃÂÃÂESP32: rien ÃÂÃÂÃÂÃÂ  faire
+    // No ESP32: nothing to do
 #endif
 }

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -282,6 +282,8 @@ namespace esphome {
         void getFunctionsPart2();
         void functionsArrived();
         bool setFunctions(heatpumpFunctions const& functions);
+        bool isGetFunctions_ = false;
+        bool isSetFunctions_ = false;
 
         // helpers
         const char* getIfNotNull(const char* what, const char* defaultValue);

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -278,8 +278,6 @@ namespace esphome {
         //bool can_proceed() override;
 
 
-        void getFunctions();
-        void getFunctionsPart2();
         void functionsArrived();
         bool setFunctions(heatpumpFunctions const& functions);
         bool isGetFunctions_ = false;

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -38,8 +38,8 @@ void CN105Climate::setup() {
     //ESP_LOGI(TAG, "debounce_delay is set to %lu", this->debounce_delay_);
     log_info_uint32(TAG, "debounce_delay is set to ", this->debounce_delay_);
 
-    // IMPORTANT: ne pas initier la connexion UART/CN105 dans setup().
-    // On démarre la séquence dans loop() pour éviter de rater les premiers logs OTA.
+    // IMPORTANT: do not initiate the UART/CN105 connection in setup().
+    // We start the sequence in loop() to avoid missing the first OTA logs.
 
     // Initialize the internal flag based on the static configuration provided by YAML/Python
     this->supports_dual_setpoint_ = this->traits_.has_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
@@ -53,11 +53,11 @@ void CN105Climate::setup() {
  * This function is called repeatedly in the main program loop.
  */
 void CN105Climate::loop() {
-    // Bootstrap connexion CN105 (UART + CONNECT) depuis loop()
+    // Bootstrap connection CN105 (UART + CONNECT) from loop()
     this->maybe_start_connection_();
 
-    // Tant que la connexion n'a pas réussi, on ne lance AUCUN cycle/écriture (sinon ça court-circuite le délai).
-    // On continue quand même à lire/processer l'input afin de détecter le 0x7A/0x7B (connection success).
+    // As long as the connection is not successful, we do not launch ANY cycle/write (otherwise it short-circuits the delay).
+    // We still continue to read/process the input in order to detect 0x7A/0x7B (connection success).
     const bool can_talk_to_hp = this->isHeatpumpConnected_;
 
     if (!this->processInput()) {                                            // if we don't get any input: no read op
@@ -68,11 +68,26 @@ void CN105Climate::loop() {
             this->checkPendingWantedSettings();
         } else if ((this->wantedRunStates.hasChanged) && (!this->loopCycle.isCycleRunning())) {
             this->checkPendingWantedRunStates();
+        } else if ((this->isSetFunctions_) && (!this->loopCycle.isCycleRunning())) {
+            this->isSetFunctions_ = false;
+            this->setFunctions(this->functions);
+            // Also request to get function settings from heat pump to update UI with latest values.
+            this->isGetFunctions_ = true;
         } else {
             if (this->loopCycle.isCycleRunning()) {                         // if we are  running an update cycle
                 this->loopCycle.checkTimeout(this->update_interval_);
             } else { // we are not running a cycle
                 if (this->loopCycle.hasUpdateIntervalPassed(this->get_update_interval())) {
+                    if (this->isGetFunctions_) {
+                        // Reactivate requests 0x20/0x22 and bypass interval timers.
+                        // This must be done before starting a new cycle to prevent a race hazard of
+                        // request 0x22 occurring before request 0x20.
+                        this->scheduler_.enable_request(0x20);
+                        this->scheduler_.timer_bypass(0x20);
+                        this->scheduler_.enable_request(0x22);
+                        this->scheduler_.timer_bypass(0x22);
+                        this->isGetFunctions_ = false;
+                    }
                     this->buildAndSendRequestsInfoPackets();            // initiate an update cycle with this->cycleStarted();
                 }
             }

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -138,8 +138,14 @@ void CN105Climate::set_functions_get_button(FunctionsButton* Button) {
     this->Functions_get_button_ = Button;
     this->Functions_get_button_->setCallbackFunction([this]() {
         ESP_LOGI(LOG_CYCLE_TAG, "Retrieving functions");
-        // Get the settings from the heat pump
-        this->getFunctions();
+
+        if (this->Functions_sensor_ != nullptr) {
+            this->Functions_sensor_->publish_state("Operation pending, please wait.");
+        }
+
+        // Request function settings from the heat pump.
+        this->isGetFunctions_ = true;
+
         // The response is handled in heatpumpFunctions.cpp
         });
 }
@@ -148,7 +154,7 @@ void CN105Climate::set_functions_set_button(FunctionsButton* Button) {
     this->Functions_set_button_ = Button;
     this->Functions_set_button_->setCallbackFunction([this]() {
 
-        if (!functions.isValid()) {
+        if (!this->functions.isValid()) {
             if (this->Functions_sensor_ != nullptr) {
                 this->Functions_sensor_->publish_state("Please get the functions first.");
             }
@@ -156,10 +162,14 @@ void CN105Climate::set_functions_set_button(FunctionsButton* Button) {
         }
 
         ESP_LOGI(LOG_CYCLE_TAG, "Setting code %i to value %i", this->functions_code_, this->functions_value_);
-        functions.setValue(this->functions_code_, this->functions_value_);
+        this->functions.setValue(this->functions_code_, this->functions_value_);
+
+        if (this->Functions_sensor_ != nullptr) {
+            this->Functions_sensor_->publish_state("Operation pending, please wait.");
+        }
 
         // Now send the codes.
-        this->setFunctions(functions);
+        this->isSetFunctions_ = true;
 
         });
 }
@@ -263,6 +273,6 @@ void CN105Climate::add_hardware_setting(HardwareSettingSelect* setting) {
         this->functions.setValue(setting->get_code(), int_value);
 
         // Trigger write to device
-        this->setFunctions(this->functions);
+        this->isSetFunctions_ = true;
         });
 }

--- a/components/cn105/heatpumpFunctions.cpp
+++ b/components/cn105/heatpumpFunctions.cpp
@@ -5,34 +5,6 @@
 using namespace esphome;
 //#region heatpump_functions fonctions clim
 
-void CN105Climate::getFunctions() {
-    ESP_LOGV(TAG, "getting the list of functions...");
-
-    functions.clear();
-
-    uint8_t packet1[PACKET_LEN] = {};
-
-    prepareInfoPacket(packet1, PACKET_LEN);
-    packet1[5] = FUNCTIONS_GET_PART1;
-    packet1[21] = checkSum(packet1, 21);
-
-    writePacket(packet1, PACKET_LEN);
-
-    // Read command will issue part 2.
-}
-
-void CN105Climate::getFunctionsPart2() {
-    ESP_LOGV(TAG, "getting the list of functions part 2...");
-
-    uint8_t packet2[PACKET_LEN] = {};
-
-    prepareInfoPacket(packet2, PACKET_LEN);
-    packet2[5] = FUNCTIONS_GET_PART2;
-    packet2[21] = checkSum(packet2, 21);
-
-    writePacket(packet2, PACKET_LEN);
-}
-
 void CN105Climate::functionsArrived() {
 
     // Called after 2nd packet has arrived.

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -231,7 +231,7 @@ void CN105Climate::getSettingsFromResponsePacket() {
         receivedSettings.temperature = lookupByteMapValue(TEMP_MAP, TEMP, 16, data[5], "temperature reading");
     }
 
-    ESP_LOGD("Decoder", "[Temp ÃÂ°C: %f]", receivedSettings.temperature);
+    ESP_LOGD("Decoder", "[Temp °C: %f]", receivedSettings.temperature);
 
     receivedSettings.fan = lookupByteMapValue(FAN_MAP, FAN, 6, data[6], "fan reading");
     ESP_LOGD("Decoder", "[Fan: %s]", receivedSettings.fan);
@@ -303,10 +303,10 @@ void CN105Climate::getRoomTemperatureFromResponsePacket() {
         int temp = data[6];
         temp -= 128;
         receivedStatus.roomTemperature = temp / 2.0f;
-        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[6]  --> [Room ÃÂ°C: %f]", receivedStatus.roomTemperature);
+        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[6]  --> [Room °C: %f]", receivedStatus.roomTemperature);
     } else {
         receivedStatus.roomTemperature = lookupByteMapValue(ROOM_TEMP_MAP, ROOM_TEMP, 32, data[3]);
-        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[3] map --> [Room ÃÂ°C : %f]", receivedStatus.roomTemperature);
+        ESP_LOGD(LOG_TEMP_SENSOR_TAG, "data[3] map --> [Room °C : %f]", receivedStatus.roomTemperature);
     }
 
     // Update the remote temperature control sensor (Issue 290)
@@ -323,8 +323,8 @@ void CN105Climate::getRoomTemperatureFromResponsePacket() {
 
     receivedStatus.runtimeHours = float((data[11] << 16) | (data[12] << 8) | data[13]) / 60;
 
-    ESP_LOGD("Decoder", "[Room ÃÂ°C: %f]", receivedStatus.roomTemperature);
-    ESP_LOGD("Decoder", "[OAT  ÃÂ°C: %f]", receivedStatus.outsideAirTemperature);
+    ESP_LOGD("Decoder", "[Room °C: %f]", receivedStatus.roomTemperature);
+    ESP_LOGD("Decoder", "[OAT  °C: %f]", receivedStatus.outsideAirTemperature);
 
     // no change with this packet to currentStatus for operating and compressorFrequency
     receivedStatus.operating = currentStatus.operating;
@@ -507,7 +507,7 @@ void CN105Climate::processCommand() {
         this->updateSuccess();
         break;
 
-    case 0x62:  /* packet contains data (room ÃÂ°C, settings, timer, status, or functions...)*/
+    case 0x62:  /* packet contains data (room °C, settings, timer, status, or functions...)*/
         this->getDataFromResponsePacket();
         break;
     case 0x7a:  // Connection success (User / standard)

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -466,22 +466,8 @@ void CN105Climate::getDataFromResponsePacket() {
         break;
 
     case 0x20: // fallthrough
-    case 0x22: {
-        ESP_LOGD("Decoder", "[Packet Functions 0x20 et 0x22]");
-        //this->last_received_packet_sensor->publish_state("0x62-> 0x20/0x22: Data -> Packet functions");
-        if (dataLength == 0x10) {
-            if (data[0] == 0x20) {
-                functions.setData1(&data[1]);
-                ESP_LOGI(LOG_CYCLE_TAG, "Got functions packet 1, requesting part 2");
-                this->getFunctionsPart2();
-            } else {
-                functions.setData2(&data[1]);
-                ESP_LOGI(LOG_CYCLE_TAG, "Got functions packet 2");
-                this->functionsArrived();
-            }
-        }
-    }
-             break;
+    case 0x22:
+        break; // orchestrator
 
     case 0x42:
         break; // orchestrator

--- a/components/cn105/request_scheduler.cpp
+++ b/components/cn105/request_scheduler.cpp
@@ -34,12 +34,30 @@ void RequestScheduler::disable_request(uint8_t code) {
     }
 }
 
+void RequestScheduler::enable_request(uint8_t code) {
+    for (auto& req : requests_) {
+        if (req.code == code) {
+            req.disabled = false;
+            break;
+        }
+    }
+}
+
+void RequestScheduler::timer_bypass(uint8_t code) {
+    for (auto& req : requests_) {
+        if (req.code == code) {
+            req.last_request_time = 0;
+            break;
+        }
+    }
+}
+
 bool RequestScheduler::is_empty() const {
     return requests_.empty();
 }
 
 void RequestScheduler::send_request(uint8_t code, CN105Climate* context) {
-    // Obtenir le contexte si non fourni mais que le callback est disponible
+    // Get context if not provided but callback is available
     if (!context && context_callback_) {
         context = context_callback_();
     }
@@ -49,7 +67,7 @@ void RequestScheduler::send_request(uint8_t code, CN105Climate* context) {
         if (req.code != code) continue;
         if (req.disabled) { return; }
 
-        // Vérifier canSend si présent et si le contexte est disponible
+        // Check canSend if present and if context is available
         if (req.canSend && context) {
             if (!req.canSend(*context)) {
                 return;
@@ -62,12 +80,12 @@ void RequestScheduler::send_request(uint8_t code, CN105Climate* context) {
         req.awaiting = true;
         req.last_request_time = CUSTOM_MILLIS;
 
-        // Envoyer le paquet via le callback
+        // Send the packet via callback
         if (send_callback_) {
             send_callback_(req.code);
         }
 
-        // Gérer le timeout si configuré et si le callback est disponible
+        // Manage the timeout if configured and if the callback is available
         if (req.soft_timeout_ms > 0 && timeout_callback_) {
             uint8_t code_copy = req.code;
             const std::string tname = req.timeout_name.empty() ?
@@ -75,13 +93,13 @@ void RequestScheduler::send_request(uint8_t code, CN105Climate* context) {
                 req.timeout_name;
 
             timeout_callback_(tname, req.soft_timeout_ms, [this, code_copy]() {
-                // Obtenir le contexte pour send_next_after
+                // Get context for send_next_after
                 CN105Climate* ctx = nullptr;
                 if (this->context_callback_) {
                     ctx = this->context_callback_();
                 }
 
-                // Si la réponse est toujours attendue, considérer comme un échec soft et continuer
+                // If the response is still expected, consider it a soft failure and continue
                 for (auto& r : this->requests_) {
                     if (r.code == code_copy && r.awaiting) {
                         r.awaiting = false;
@@ -106,7 +124,7 @@ void RequestScheduler::send_request(uint8_t code, CN105Climate* context) {
 }
 
 void RequestScheduler::mark_response_seen(uint8_t code, CN105Climate* context) {
-    // Obtenir le contexte si non fourni mais que le callback est disponible
+    // Get context if not provided but callback is available
     if (!context && context_callback_) {
         context = context_callback_();
     }
@@ -117,7 +135,7 @@ void RequestScheduler::mark_response_seen(uint8_t code, CN105Climate* context) {
             req.failures = 0;
             ESP_LOGD(LOG_CYCLE_TAG, "Received %s <0x%02X>", req.description, req.code);
 
-            // Appeler le callback onResponse si présent et si le contexte est disponible
+            // Call the onResponse callback if present and if the context is available
             if (req.onResponse && context) {
                 req.onResponse(*context);
             }
@@ -127,12 +145,12 @@ void RequestScheduler::mark_response_seen(uint8_t code, CN105Climate* context) {
 }
 
 void RequestScheduler::send_next_after(uint8_t previous_code, CN105Climate* context) {
-    // Obtenir le contexte si non fourni mais que le callback est disponible
+    // Get context if not provided but callback is available
     if (!context && context_callback_) {
         context = context_callback_();
     }
 
-    // Trouver l'index de départ (par code) puis essayer les entrées activables suivantes dans l'ordre
+    // Find the starting index (by code) then try the next activateable entries in order
     int start = -1;
     for (size_t i = 0; i < requests_.size(); ++i) {
         if (requests_[i].code == previous_code) {
@@ -151,7 +169,7 @@ void RequestScheduler::send_next_after(uint8_t previous_code, CN105Climate* cont
             continue;
         }
 
-        // Vérifier canSend si présent et si le contexte est disponible
+        // Check canSend if present and if context is available
         if (req.canSend && context) {
             if (!req.canSend(*context)) {
                 if (req.log_tag) {
@@ -161,7 +179,7 @@ void RequestScheduler::send_next_after(uint8_t previous_code, CN105Climate* cont
             }
         }
 
-        if (req.interval_ms > 0 && (CUSTOM_MILLIS - req.last_request_time < req.interval_ms)) {
+        if (req.interval_ms > 0 && (CUSTOM_MILLIS - req.last_request_time < req.interval_ms) && req.last_request_time > 0) {
             if (req.log_tag) {
                 ESP_LOGD(req.log_tag, "Skipping %s (0x%02X) - interval not elapsed (elapsed: %lu, interval: %u)",
                     req.description, req.code,
@@ -170,24 +188,24 @@ void RequestScheduler::send_next_after(uint8_t previous_code, CN105Climate* cont
             continue;
         }
 
-        // Envoyer la requête trouvée
+        // Send found request
         send_request(req.code, context);
         return;
     }
 
-    // Plus de requêtes → terminer le cycle
+    // No more requests → end the cycle
     if (terminate_callback_) {
         terminate_callback_();
     }
 }
 
 bool RequestScheduler::process_response(uint8_t code, CN105Climate* context) {
-    // Obtenir le contexte si non fourni mais que le callback est disponible
+    // Get context if not provided but callback is available
     if (!context && context_callback_) {
         context = context_callback_();
     }
 
-    // Chercher si le code est géré par le scheduler
+    // Find out if the code is managed by the scheduler
     bool handled = false;
     for (auto& req : requests_) {
         if (req.code == code) {
@@ -203,8 +221,8 @@ bool RequestScheduler::process_response(uint8_t code, CN105Climate* context) {
 }
 
 void RequestScheduler::loop() {
-    // Actuellement, la gestion des timeouts est faite via des callbacks
-    // Cette méthode est prévue pour une gestion future si nécessaire
-    // (par exemple, pour vérifier les timeouts manuellement dans le loop principal)
+    // Currently, timeouts are managed via callbacks
+    // This method is intended for future management if necessary
+    // (for example, to check timeouts manually in the main loop)
 }
 

--- a/components/cn105/request_scheduler.h
+++ b/components/cn105/request_scheduler.h
@@ -11,44 +11,44 @@ namespace esphome {
 
     /**
      * @class RequestScheduler
-     * @brief Gère la file d'attente des requêtes cycliques et leur enchaînement.
+     * @brief Manages the cyclical request queue and their sequence.
      *
-     * Cette classe extrait la logique de gestion des requêtes INFO du composant CN105Climate
-     * pour respecter le principe de responsabilité unique (SRP).
+     *This class extracts INFO request management logic from the CN105Climate component
+     *to respect the single responsibility principle (SRP).
      */
     class RequestScheduler {
     public:
         /**
-         * @brief Type de callback pour l'envoi d'un paquet
-         * @param code Le code de la requête à envoyer
+         * @brief Type of callback for sending a packet
+         * @param code The code of the request to send
          */
         using SendCallback = std::function<void(uint8_t)>;
 
         /**
-         * @brief Type de callback pour la gestion des timeouts
-         * @param name Nom unique du timeout
-         * @param timeout_ms Durée du timeout en millisecondes
-         * @param callback Fonction à appeler à l'expiration du timeout
+         * @brief Type of callback for timeout management
+         * @param name Unique name of the timeout
+         * @param timeout_ms Duration of the timeout in milliseconds
+         * @param callback Function to call when timeout expires
          */
         using TimeoutCallback = std::function<void(const std::string&, uint32_t, std::function<void()>)>;
 
         /**
-         * @brief Type de callback pour terminer un cycle
+         * @brief Type of callback to end a cycle
          */
         using TerminateCallback = std::function<void()>;
 
         /**
-         * @brief Type de callback pour obtenir le contexte CN105Climate (pour canSend et onResponse)
-         * @return Pointeur vers CN105Climate (peut être nullptr)
+         * @brief Type of callback to obtain the CN105Climate context (for canSend and onResponse)
+         * @return Pointer to CN105Climate (can be nullptr)
          */
         using ContextCallback = std::function<CN105Climate* ()>;
 
         /**
-         * @brief Constructeur
-         * @param send_callback Callback pour envoyer un paquet
-         * @param timeout_callback Callback pour gérer les timeouts (peut être nullptr si non utilisé)
-         * @param terminate_callback Callback pour terminer un cycle
-         * @param context_callback Callback pour obtenir le contexte CN105Climate (pour canSend et onResponse)
+         * @brief Constructor
+         * @param send_callback Callback to send a packet
+         * @param timeout_callback Callback to manage timeouts (can be nullptr if not used)
+         * @param terminate_callback Callback to end a cycle
+         * @param context_callback Callback to get the CN105Climate context (for canSend and onResponse)
          */
         RequestScheduler(
             SendCallback send_callback,
@@ -58,69 +58,81 @@ namespace esphome {
         );
 
         /**
-         * @brief Enregistre une requête dans la file d'attente
-         * @param req La requête à enregistrer (référence non-const pour permettre modification)
+         * @brief Saves a request to the queue
+         * @param req The query to save (non-const reference to allow modification)
          */
         void register_request(InfoRequest& req);
 
         /**
-         * @brief Vide la liste des requêtes
+         * @brief Empty the list of requests
          */
         void clear_requests();
 
         /**
-         * @brief Désactive une requête par son code
-         * @param code Le code de la requête à désactiver
+         * @brief Disable a request by its code
+         * @param code The request code to deactivate
          */
         void disable_request(uint8_t code);
 
         /**
-         * @brief Vérifie si la file d'attente est vide
-         * @return true si vide, false sinon
+         * @brief Enable a request by its code
+         * @param code The request code to activate
+         */
+        void enable_request(uint8_t code);
+
+        /**
+         * @brief Bypass the interval timer of a request by its code
+         * @param code The request code to bypass
+         */
+        void timer_bypass(uint8_t code);
+
+        /**
+         * @brief Check if the queue is empty
+         * @return true if empty, false otherwise
          */
         bool is_empty() const;
 
         /**
-         * @brief Envoie la prochaine requête après celle avec le code spécifié
-         * @param previous_code Le code de la requête précédente (0x00 pour démarrer)
-         * @param context Contexte CN105Climate pour vérifier canSend (peut être nullptr, utilise context_callback_ si fourni)
+         * @brief Send the next request after the one with the specified code
+         * @param previous_code The code of the previous request (0x00 to start)
+         * @param context CN105Climate context to check canSend (can be nullptr, uses context_callback_ if provided)
          */
         void send_next_after(uint8_t previous_code, CN105Climate* context = nullptr);
 
         /**
-         * @brief Marque une réponse comme reçue pour un code donné et appelle le callback onResponse si présent
-         * @param code Le code de la requête dont la réponse a été reçue
-         * @param context Contexte CN105Climate pour appeler onResponse (peut être nullptr)
+         * @brief Marks a response as received for a given code and calls the onResponse callback if present
+         * @param code The code of the request whose response was received
+         * @param context CN105Climate context to call onResponse (can be nullptr)
          */
         void mark_response_seen(uint8_t code, CN105Climate* context = nullptr);
 
         /**
-         * @brief Traite une réponse reçue
-         * @param code Le code de la réponse reçue
-         * @param context Contexte CN105Climate pour appeler onResponse (peut être nullptr, utilise context_callback_ si fourni)
-         * @return true si la réponse a été traitée, false sinon
+         * @brief Processes a response received
+         * @param code The code of the response received
+         * @param context CN105Climate context to call onResponse (can be nullptr, uses context_callback_ if provided)
+         * @return true if the response has been processed, false otherwise
          */
         bool process_response(uint8_t code, CN105Climate* context = nullptr);
 
         /**
-         * @brief Méthode à appeler dans le loop principal pour gérer les timeouts
-         * Note: La gestion des timeouts est actuellement gérée via des callbacks,
-         * cette méthode est prévue pour une gestion future si nécessaire.
+         * @brief Method to call in the main loop to manage timeouts
+         *Note: Timeout management is currently managed via callbacks,
+         *this method is intended for future management if necessary.
          */
         void loop();
 
     private:
-        std::vector<InfoRequest> requests_;          // File d'attente des requêtes
-        int current_request_index_;                  // Index de la requête courante
-        SendCallback send_callback_;                  // Callback pour envoyer un paquet
-        TimeoutCallback timeout_callback_;            // Callback pour gérer les timeouts
-        TerminateCallback terminate_callback_;        // Callback pour terminer un cycle
-        ContextCallback context_callback_;            // Callback pour obtenir le contexte CN105Climate
+        std::vector<InfoRequest> requests_;         // Requests queue
+        int current_request_index_;                 // Index of the current request
+        SendCallback send_callback_;                // Callback to send a packet
+        TimeoutCallback timeout_callback_;          // Callback to manage timeouts
+        TerminateCallback terminate_callback_;      // Callback to end a cycle
+        ContextCallback context_callback_;          // Callback to get the CN105Climate context
 
         /**
-         * @brief Envoie une requête spécifique par son code
-         * @param code Le code de la requête à envoyer
-         * @param context Contexte CN105Climate pour vérifier canSend (peut être nullptr)
+         * @brief Sends a specific request by its code
+         * @param code The code of the request to send
+         * @param context CN105Climate context to check canSend (can be nullptr)
          */
         void send_request(uint8_t code, CN105Climate* context = nullptr);
     };


### PR DESCRIPTION
Setting and getting functions from my heat pump seems unreliable. I assume it is related to the background cycle packets colliding with the function related packets. Hold off getting and setting functions until no cycle packets are requested and also hold off all other packets until the get functions has completed.