### PR TITLE
fix(climate_proxy): use HA unit system to detect Fahrenheit (#579)

### DIFF
--- a/custom_components/mitsubishi_climate_proxy/climate.py
+++ b/custom_components/mitsubishi_climate_proxy/climate.py
@@ -158,12 +158,17 @@ class MitsubishiHybridClimate(ClimateEntity):
 
     @property
     def _source_unit(self) -> str:
-        """Return the temperature unit advertised by the source entity."""
-        if self._source_state:
-            return self._source_state.attributes.get(
-                "unit_of_measurement", UnitOfTemperature.CELSIUS
-            )
-        return UnitOfTemperature.CELSIUS
+        """Return the temperature unit used by HA for climate state attributes.
+
+        Climate entities in HA do NOT expose 'unit_of_measurement' in their
+        state attributes (unlike sensor entities).  Instead, HA converts all
+        climate temperature values to match the user's configured unit system
+        before storing them in the state object.
+
+        Therefore the reliable way to know what unit the source values are in
+        is to read the HA instance's unit system.
+        """
+        return self.hass.config.units.temperature_unit
 
     def _normalize_temp(self, val: Optional[float]) -> Optional[float]:
         """Convert a source temperature to °C if the source advertises °F.

--- a/custom_components/mitsubishi_climate_proxy/manifest.json
+++ b/custom_components/mitsubishi_climate_proxy/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "mitsubishi_climate_proxy",
     "name": "Mitsubishi Climate Proxy",
-    "version": "2026.3.2",
+    "version": "2026.5.1",
     "documentation": "https://github.com/echavet/MitsubishiCN105ESPHome",
     "dependencies": [],
     "codeowners": [


### PR DESCRIPTION
## Summary

Fixes #579 — The `mitsubishi_climate_proxy` HACS integration double-converts temperatures when Home Assistant is configured in Fahrenheit (°F), resulting in values ~2.26× too high (e.g. `69°F → 156°F`).

## Root Cause

The `_source_unit` property (introduced in v2026.3.2, PR #608) reads `unit_of_measurement` from the source climate entity's state attributes to detect Fahrenheit. However, **climate entities in HA do NOT expose this attribute** in their state dictionary (unlike `sensor` entities). The `.get()` call always returns `None`, falling back to `CELSIUS`, which means the normalization logic (`_normalize_temp` / `_denormalize_temp`) never activates.

As a result:
- Source values are already in °F (because HA converts them per the user's unit system)
- Proxy declares `temperature_unit = CELSIUS`  
- HA applies a second C→F conversion on display → **double conversion**

## Fix

Replace the unreliable attribute lookup with `self.hass.config.units.temperature_unit`, which reliably reflects the HA instance's configured unit system.

```diff
 @property
 def _source_unit(self) -> str:
-    if self._source_state:
-        return self._source_state.attributes.get(
-            "unit_of_measurement", UnitOfTemperature.CELSIUS
-        )
-    return UnitOfTemperature.CELSIUS
+    return self.hass.config.units.temperature_unit
```

The rest of the normalization infrastructure from v2026.3.2 remains unchanged and works correctly once `_source_unit` returns the proper value.

## Changes
- **`climate.py`**: Fix `_source_unit` to use `hass.config.units.temperature_unit`
- **`manifest.json`**: Bump version to `2026.5.1`

## Confirmed by users
- @Twenty5Schmeckels (original reporter)
- @jmooradi  
- @DavidWAbrahams (identified the exact root cause in [comment](https://github.com/echavet/MitsubishiCN105ESPHome/issues/579#issuecomment-4277868485))
