### PR TITLE
ci: update build workflow configuration for improved pipeline efficiency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Unit Tests (C++)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Configure
       run: cmake -B tests/unit/build -S tests/unit -DCMAKE_BUILD_TYPE=Release
@@ -53,7 +53,7 @@ jobs:
       USERNAME: test
       PASSWORD: github-run
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Generate random secret
       env:
         keys: >-


### PR DESCRIPTION

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.


Solution: use actions/checkout@v5