### PR TITLE
refactor: replace 6 connection booleans with DriverState FSM enum

### DIFF
--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -9,6 +9,24 @@
 
 using namespace esphome;
 
+const char* esphome::driver_state_to_str(DriverState s) {
+    switch (s) {
+        case DriverState::BOOT:         return "BOOT";
+        case DriverState::WAIT_WIFI:    return "WAIT_WIFI";
+        case DriverState::WAIT_GRACE:   return "WAIT_GRACE";
+        case DriverState::CONNECTING:   return "CONNECTING";
+        case DriverState::CONNECTED:    return "CONNECTED";
+        case DriverState::DISCONNECTED: return "DISCONNECTED";
+        default:                        return "UNKNOWN";
+    }
+}
+
+void CN105Climate::transition_to_(DriverState next) {
+    if (state_ == next) return;
+    ESP_LOGI("FSM", "State: %s -> %s", driver_state_to_str(state_), driver_state_to_str(next));
+    state_ = next;
+}
+
 
 CN105Climate::CN105Climate(uart::UARTComponent* uart) :
     UARTDevice(uart),
@@ -36,7 +54,7 @@ CN105Climate::CN105Climate(uart::UARTComponent* uart) :
     this->traits_.set_visual_temperature_step(ESPMHP_TEMPERATURE_STEP);
 
 
-    this->isUARTConnected_ = false;
+    // state_ is initialized to BOOT in the header
     this->use_temperature_encoding_b_ = false;
     this->wideVaneAdj = false;
     this->functions = heatpumpFunctions();
@@ -278,13 +296,13 @@ void CN105Climate::startRemoteTempKeepAlive() {
     log_info_uint32(LOG_REMOTE_TEMP, "Starting remote temperature keep-alive with interval ", this->remote_temp_keepalive_interval_ms_);
 
     this->set_interval(SCHEDULER_REMOTE_TEMP_KEEPALIVE, this->remote_temp_keepalive_interval_ms_, [this]() {
-        if (this->remoteTemperature_ > 0 && this->isHeatpumpConnected_) {
+        if (this->remoteTemperature_ > 0 && this->isHeatpumpConnected()) {
             ESP_LOGD(LOG_REMOTE_TEMP, "Keep-alive: re-sending remote temperature %.1f", this->remoteTemperature_);
             // Send the temperature packet without resetting the watchdog timeout
             // (watchdog is only reset when HA sends a new value via set_remote_temperature)
             this->shouldSendExternalTemperature_ = true;
         } else {
-            if (!this->isHeatpumpConnected_) {
+            if (!this->isHeatpumpConnected()) {
                 ESP_LOGW(LOG_REMOTE_TEMP, "Keep-alive skipped: Heatpump not connected!");
             } else {
                 ESP_LOGD(LOG_REMOTE_TEMP, "Keep-alive skipped: remoteTemp %.1f <= 0", this->remoteTemperature_);
@@ -339,7 +357,7 @@ void CN105Climate::setupUART() {
     log_info_uint32(TAG, "setupUART() with baudrate ", this->parent_->get_baud_rate());
     ESP_LOGI(LOG_CONN_TAG, "setupUART(): baud=%d tx=%d rx=%d (UART port=%d)", this->parent_->get_baud_rate(), this->tx_pin_, this->rx_pin_, this->uart_port_);
     this->setHeatpumpConnected(false);
-    this->isUARTConnected_ = false;
+    // isUARTConnected_ replaced by state_ (set to CONNECTING after successful config below)
 
     // just for debugging purpose, a way to use a button i, yaml to trigger a reconnect
     this->uart_setup_switch = true;
@@ -348,7 +366,7 @@ void CN105Climate::setupUART() {
         this->parent_->get_parity() == uart::UART_CONFIG_PARITY_EVEN &&
         this->parent_->get_stop_bits() == 1) {
         ESP_LOGI(LOG_CONN_TAG, "UART configured as SERIAL_8E1");
-        this->isUARTConnected_ = true;
+        this->transition_to_(DriverState::CONNECTING);
         this->parser_.reset();
     } else {
         ESP_LOGW(LOG_CONN_TAG, "UART is not configured as SERIAL_8E1");
@@ -357,7 +375,11 @@ void CN105Climate::setupUART() {
 }
 
 void CN105Climate::setHeatpumpConnected(bool state) {
-    this->isHeatpumpConnected_ = state;
+    if (state) {
+        this->transition_to_(DriverState::CONNECTED);
+    } else if (state_ == DriverState::CONNECTED) {
+        this->transition_to_(DriverState::DISCONNECTED);
+    }
     if (this->hp_uptime_connection_sensor_ != nullptr) {
         if (state) {
             this->hp_uptime_connection_sensor_->start();
@@ -372,8 +394,7 @@ void CN105Climate::disconnectUART() {
     ESP_LOGD(TAG, "disconnectUART()");
     this->uart_setup_switch = false;
     this->setHeatpumpConnected(false);
-    //this->isHeatpumpConnected_ = false;
-    //this->isUARTConnected_ = false;
+    // Legacy booleans removed — state managed by FSM (setHeatpumpConnected / transition_to_)
     this->firstRun = true;
     this->publish_state();
 

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -38,6 +38,18 @@
 
 namespace esphome {
 
+    // Connection lifecycle FSM — replaces 6 scattered booleans
+    enum class DriverState : uint8_t {
+        BOOT,           // setup() done, loop() not yet called
+        WAIT_WIFI,      // WiFi required but not yet connected
+        WAIT_GRACE,     // WiFi OK, OTA grace delay in progress
+        CONNECTING,     // UART configured, CONNECT sent, awaiting 0x7A/0x7B
+        CONNECTED,      // Handshake succeeded, ready to poll
+        DISCONNECTED,   // Response timeout, reconnection needed
+    };
+
+    const char* driver_state_to_str(DriverState s);
+
     void log_info_uint32(const char* tag, const char* msg, uint32_t value, const char* suffix = "");
     void log_debug_uint32(const char* tag, const char* msg, uint32_t value, const char* suffix = "");
 
@@ -191,6 +203,13 @@ namespace esphome {
         bool isHeatpumpConnectionActive();
         void reconnectIfConnectionLost();
 
+        // FSM
+        DriverState driver_state() const { return state_; }
+        void transition_to_(DriverState next);
+        // Compatibility accessors (replace former booleans)
+        bool isUARTReady_() const { return state_ >= DriverState::CONNECTING; }
+        bool isHeatpumpConnected() const { return state_ == DriverState::CONNECTED; }
+
         void sendWantedSettings();
         void sendWantedSettingsDelegate();
         // Use the temperature from an external sensor. Use
@@ -265,8 +284,9 @@ namespace esphome {
         /// le bouton de setup de l'UART
         bool uart_setup_switch;
 
-        bool isUARTConnected_ = false;
-        bool isHeatpumpConnected_ = false;
+        // Legacy booleans replaced by DriverState FSM (see state_)
+        // bool isUARTConnected_  → isUARTReady_()
+        // bool isHeatpumpConnected_ → isHeatpumpConnected()
         bool shouldSendExternalTemperature_ = false;
         float remoteTemperature_ = 0;
 
@@ -493,12 +513,9 @@ namespace esphome {
         bool pending_check_is_active_ = true;
         bool has_pending_packet_ = false;
 
-        // Bootstrap de connexion (loop)
+        // Connection lifecycle FSM
+        DriverState state_ = DriverState::BOOT;
         uint32_t boot_ms_ = 0;
-        bool conn_bootstrap_started_ = false;
-        bool conn_wait_logged_ = false;
-        bool conn_grace_logged_ = false;
-        bool conn_timeout_armed_ = false;
         uint32_t conn_bootstrap_delay_ms_{ 10000 };  // par dÃÂ©faut 10s
 
         bool installer_mode_{ false };

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -58,7 +58,7 @@ void CN105Climate::loop() {
 
     // As long as the connection is not successful, we do not launch ANY cycle/write (otherwise it short-circuits the delay).
     // We still continue to read/process the input in order to detect 0x7A/0x7B (connection success).
-    const bool can_talk_to_hp = this->isHeatpumpConnected_;
+    const bool can_talk_to_hp = this->isHeatpumpConnected();
 
     if (!this->processInput()) {                                            // if we don't get any input: no read op
         if (!can_talk_to_hp) {
@@ -96,45 +96,58 @@ void CN105Climate::loop() {
 }
 
 void CN105Climate::maybe_start_connection_() {
-    if (this->conn_bootstrap_started_) return;
-
-    // Timeout global: au bout de 2 minutes on démarre même sans WiFi
-    if (!this->conn_timeout_armed_) {
-        this->conn_timeout_armed_ = true;
-        this->set_timeout("cn105_bootstrap_timeout", 120000, [this]() {
-            if (this->conn_bootstrap_started_) return;
-            ESP_LOGW(LOG_CONN_TAG, "Bootstrap connexion: timeout 120s, démarrage CN105 malgré tout");
-            this->conn_bootstrap_started_ = true;
-            this->setupUART();
-            this->sendFirstConnectionPacket();
+    switch (state_) {
+        case DriverState::BOOT: {
+            // Arm a 120s global timeout (fires once, forces connection even without WiFi)
+            this->set_timeout("cn105_bootstrap_timeout", 120000, [this]() {
+                if (state_ >= DriverState::CONNECTING) return;
+                ESP_LOGW(LOG_CONN_TAG, "Bootstrap connexion: timeout 120s, démarrage CN105 malgré tout");
+                this->setupUART();
+                this->sendFirstConnectionPacket();
             });
-    }
 
 #ifdef USE_WIFI
-    if (wifi::global_wifi_component != nullptr && !wifi::global_wifi_component->is_connected()) {
-        if (!this->conn_wait_logged_) {
-            this->conn_wait_logged_ = true;
-            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: attente WiFi avant init UART/CONNECT");
-        }
-        return;
-    }
+            if (wifi::global_wifi_component != nullptr && !wifi::global_wifi_component->is_connected()) {
+                this->transition_to_(DriverState::WAIT_WIFI);
+                ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: attente WiFi avant init UART/CONNECT");
+                return;
+            }
 #endif
-
-    // Délai de grâce pour laisser le flux de logs OTA se connecter (évite de rater la séquence CONNECT)
-    const uint32_t grace_ms = this->conn_bootstrap_delay_ms_;
-    const uint32_t elapsed = CUSTOM_MILLIS - this->boot_ms_;
-    if (elapsed < grace_ms) {
-        if (!this->conn_grace_logged_) {
-            this->conn_grace_logged_ = true;
-            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: délai de grâce %ums pour logs OTA", grace_ms);
+            // WiFi ready (or no WiFi) — check grace delay
+            this->transition_to_(DriverState::WAIT_GRACE);
+            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: délai de grâce %ums pour logs OTA", this->conn_bootstrap_delay_ms_);
+            return;
         }
-        return;
-    }
 
-    this->conn_bootstrap_started_ = true;
-    ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: init UART + envoi CONNECT (loop)");
-    this->setupUART();
-    this->sendFirstConnectionPacket();
+        case DriverState::WAIT_WIFI: {
+#ifdef USE_WIFI
+            if (wifi::global_wifi_component != nullptr && !wifi::global_wifi_component->is_connected()) {
+                return;  // still waiting
+            }
+#endif
+            this->transition_to_(DriverState::WAIT_GRACE);
+            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: WiFi connecté, délai de grâce %ums", this->conn_bootstrap_delay_ms_);
+            return;
+        }
+
+        case DriverState::WAIT_GRACE: {
+            const uint32_t elapsed = CUSTOM_MILLIS - this->boot_ms_;
+            if (elapsed < this->conn_bootstrap_delay_ms_) {
+                return;  // grace delay not elapsed yet
+            }
+            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: init UART + envoi CONNECT (loop)");
+            this->setupUART();
+            this->sendFirstConnectionPacket();
+            // setupUART() transitions to CONNECTING if UART config is valid
+            return;
+        }
+
+        case DriverState::CONNECTING:
+        case DriverState::CONNECTED:
+        case DriverState::DISCONNECTED:
+            // Nothing to do — connection already started or managed elsewhere
+            return;
+    }
 }
 
 uint32_t CN105Climate::get_update_interval() const { return this->update_interval_; }

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -8,6 +8,8 @@ using namespace esphome;
  * processInput: reads available bytes from UART and feeds them to the FrameParser.
  * When a complete frame is detected, delegates to processDataPacket().
  */
+
+
 bool CN105Climate::processInput(void) {
     bool processed = false;
     while (this->get_hw_serial_()->available()) {
@@ -40,7 +42,7 @@ void CN105Climate::processDataPacket() {
     this->hpPacketDebug(this->parser_.raw(), this->parser_.frame_size(), "READ");
 
     // During handshake, log every received frame for diagnostics
-    if (!this->isHeatpumpConnected_) {
+    if (!this->isHeatpumpConnected()) {
         ESP_LOGD(LOG_CONN_TAG, "RX during handshake (cmd=0x%02X len=%d)",
             this->parser_.command(), this->parser_.data_length());
         this->hpPacketDebug(this->parser_.raw(), this->parser_.frame_size(), LOG_CONN_TAG);
@@ -56,7 +58,7 @@ void CN105Climate::processDataPacket() {
     } else {
         ESP_LOGW("chkSum", "KO -> checksum mismatch (cmd=0x%02X len=%d)",
             this->parser_.command(), this->parser_.data_length());
-        if (!this->isHeatpumpConnected_) {
+        if (!this->isHeatpumpConnected()) {
             ESP_LOGD(LOG_CONN_TAG, "Checksum KO during handshake");
             this->hpPacketDebug(this->parser_.raw(), this->parser_.frame_size(), LOG_CONN_TAG);
         }
@@ -488,7 +490,7 @@ void CN105Climate::processCommand() {
             (this->parser_.command() == 0x7b) ? "Installer" : "User",
             this->parser_.command());
         this->hpPacketDebug(this->parser_.raw(), this->parser_.frame_size(), LOG_CONN_TAG);
-        //this->isHeatpumpConnected_ = true;
+        // isHeatpumpConnected_ replaced by FSM transition in setHeatpumpConnected()
         this->setHeatpumpConnected(true);
         // let's say that the last complete cycle was over now
         this->loopCycle.lastCompleteCycleMs = CUSTOM_MILLIS;

--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -9,7 +9,7 @@ uint8_t CN105Climate::checkSum(uint8_t bytes[], int len) {
 
 
 void CN105Climate::sendFirstConnectionPacket() {
-    if (this->isUARTConnected_) {
+    if (this->isUARTReady_()) {
         this->lastReconnectTimeMs = CUSTOM_MILLIS;          // marker to prevent to many reconnections
         this->setHeatpumpConnected(false);
         uint8_t packet[CONNECT_LEN];
@@ -33,7 +33,7 @@ void CN105Climate::sendFirstConnectionPacket() {
 
         // we wait for a 10s timeout to check if the hp has replied to connection packet
         this->set_timeout("checkFirstConnection", 10000, [this]() {
-            if (!this->isHeatpumpConnected_) {
+            if (!this->isHeatpumpConnected()) {
                 ESP_LOGE(LOG_CONN_TAG, "--> Heatpump did not reply: NOT CONNECTED <--");
                 // Fallback automatique: si le mode installateur est demandé mais que la PAC ignore 0x5B,
                 // on retente une fois en mode standard (0x5A) pour préserver la connectivité.
@@ -90,7 +90,7 @@ void CN105Climate::prepareSetPacket(uint8_t* packet, int length) {
 
 void CN105Climate::writePacket(uint8_t* packet, int length, bool checkIsActive) {
 
-    if ((this->isUARTConnected_) &&
+    if ((this->isUARTReady_()) &&
         (this->isHeatpumpConnectionActive() || (!checkIsActive))) {
 
         ESP_LOGD(TAG, "writing packet...");
@@ -121,7 +121,7 @@ void CN105Climate::writePacket(uint8_t* packet, int length, bool checkIsActive) 
 
 void CN105Climate::try_write_pending_packet() {
     if (!this->has_pending_packet_) return;
-    if (!this->isUARTConnected_) {
+    if (!this->isUARTReady_()) {
         this->reconnectUART();
         this->set_timeout("write", 2000, [this]() { this->try_write_pending_packet(); });
         return;
@@ -396,7 +396,7 @@ void CN105Climate::sendWantedSettingsDelegate() {
  *
 */
 void CN105Climate::sendWantedSettings() {
-    if (this->isHeatpumpConnectionActive() && this->isUARTConnected_) {
+    if (this->isHeatpumpConnectionActive() && this->isUARTReady_()) {
         if (CUSTOM_MILLIS - this->lastSend > 300) {        // we don't want to send too many packets
 
             //this->cycleEnded();   // only if we let the cycle be interrupted to send wented settings
@@ -443,7 +443,7 @@ void CN105Climate::buildAndSendInfoPacket(uint8_t code) {
 
 
 void CN105Climate::buildAndSendRequestsInfoPackets() {
-    if (this->isHeatpumpConnected_) {
+    if (this->isHeatpumpConnected()) {
         ESP_LOGV(LOG_UPD_INT_TAG, "triggering infopacket because of update interval tick");
         ESP_LOGV("CONTROL_WANTED_SETTINGS", "hasChanged is %s", wantedSettings.hasChanged ? "true" : "false");
         this->loopCycle.cycleStarted();

--- a/examples/m5stack-atoms3/includes/sensor-config.yaml
+++ b/examples/m5stack-atoms3/includes/sensor-config.yaml
@@ -5,7 +5,7 @@ sensor:
     name: "dg_uart_connected"
     entity_category: DIAGNOSTIC
     lambda: |-
-      return (bool) id(atoms3_clim).isUARTConnected_;
+      return (bool) id(atoms3_clim).isUARTReady_();
     update_interval: 30s
 
   - platform: template

--- a/examples/root-configs/esp32-test.yaml
+++ b/examples/root-configs/esp32-test.yaml
@@ -149,14 +149,14 @@ sensor:
     name: "dg_uart_connected"
     entity_category: DIAGNOSTIC
     lambda: |-
-      return (bool) id(esp32_clim).isUARTConnected_;
+      return (bool) id(esp32_clim).isUARTReady_();
     update_interval: 30s
 
   - platform: template
     name: "dg_hp_connected"
     entity_category: DIAGNOSTIC
     lambda: |-
-      return (bool) id(esp32_clim).isUARTConnected_;
+      return (bool) id(esp32_clim).isUARTReady_();
     update_interval: 30s
 
   - platform: template


### PR DESCRIPTION
Introduce an explicit DriverState enum (BOOT, WAIT_WIFI, WAIT_GRACE, CONNECTING, CONNECTED, DISCONNECTED) to replace 6 scattered booleans:
  - conn_bootstrap_started_
  - conn_wait_logged_
  - conn_grace_logged_
  - conn_timeout_armed_
  - isUARTConnected_
  - isHeatpumpConnected_

Key changes:
- New enum class DriverState in esphome namespace
- transition_to_() logs every state change under [FSM] tag
- Compatibility accessors: isUARTReady_(), isHeatpumpConnected()
- maybe_start_connection_() refactored from if/else chain to switch
- setHeatpumpConnected() now drives FSM transitions
- YAML example lambdas updated to use isUARTReady_()

Net: -6 member variables, +1 enum, 0 logic changes.