### PR TITLE
feat(proxy): add swing_horizontal_mode for WideVane control

### DIFF
--- a/custom_components/mitsubishi_climate_proxy/README.md
+++ b/custom_components/mitsubishi_climate_proxy/README.md
@@ -12,6 +12,7 @@ This component wraps the ESPHome entity and provides a "Proxy" entity that:
 *   Shows **1 Slider** in **Heat**, **Cool**, and **Auto** modes.
 *   Shows **2 Sliders** in **Heat/Cool** mode.
 *   Intelligently maps single-setpoint adjustments to the underlying dual-setpoint ESPHome entity.
+*   Exposes **independent horizontal vane (WideVane)** control via the HA-native `swing_horizontal_mode` API (requires HA 2024.12+).
 
 ## Prerequisites
 
@@ -43,6 +44,7 @@ This integration now supports configuration directly via the Home Assistant user
 4.  Follow the on-screen instructions:
     *   Select the source ESPHome entity (e.g., `climate.living_room_esphome`).
     *   Give your new proxy entity a name (e.g., `Living Room Climate`).
+    *   *(Optional)* Select the horizontal vane select entity (e.g., `select.living_room_horizontal_vane`) to enable WideVane control in the climate card.
 5.  Click **Submit**.
 
 Your new entity will be created immediately.
@@ -56,8 +58,9 @@ If you prefer to define your entities in YAML, you can still add this to your `c
 
 climate:
   - platform: mitsubishi_climate_proxy
-    source_entity: climate.chambre_esphome  # The ID of your real ESPHome entity
-    name: Chambre Hybrid                    # The name of the new entity to use in your Dashboard
+    source_entity: climate.chambre_esphome     # The ID of your real ESPHome entity
+    name: Chambre Hybrid                       # The name of the new entity to use in your Dashboard
+    horizontal_vane_entity: select.chambre_horizontal_vane  # (Optional) WideVane select entity
 ```
 
 ## Dashboard Setup
@@ -71,10 +74,20 @@ entity: climate.living_room_climate # Use the new proxy entity here
 
 ## How it works
 
+### Temperature Setpoints
 *   **Heat Mode**: Controls `target_temp_low`.
 *   **Cool Mode**: Controls `target_temp_high`.
 *   **Auto Mode**: Controls the midpoint of the range (moving both low and high to maintain the spread).
 *   **Heat/Cool Mode**: Exposes both Low and High setpoints.
+
+### Horizontal Vane (WideVane)
+When a `horizontal_vane_entity` is configured, the proxy:
+*   Reads the current vane position from the ESPHome `select` entity
+*   Exposes it as `swing_horizontal_mode` (HA-native, requires HA **2024.12+**)
+*   Forwards position changes via the `select.select_option` service
+*   Updates in real-time when the vane position changes (state tracking)
+
+This allows the WideVane to appear directly in the standard climate card alongside the vertical swing.
 
 ## Under the Hood: How it solves the UI Glitch
 
@@ -86,6 +99,7 @@ This component uses the **Proxy Pattern**. It mirrors the state of your real ESP
 
 *   **When in `HEAT` or `AUTO` mode:** The component masks the "Dual Setpoint" capability. Home Assistant believes the device only supports a single target and renders **one slider**.
 *   **When in `HEAT_COOL` mode:** The component reveals the "Dual Setpoint" capability. Home Assistant renders **two sliders**.
+*   **When a horizontal vane entity is configured:** The component adds `SWING_HORIZONTAL_MODE` to the features, making the horizontal swing selector appear in the climate UI.
 
 ### Fahrenheit Compatibility
 

--- a/custom_components/mitsubishi_climate_proxy/climate.py
+++ b/custom_components/mitsubishi_climate_proxy/climate.py
@@ -1,3 +1,8 @@
+## climate.py — Mitsubishi Climate Proxy
+## Role: Wraps an ESPHome CN105 climate entity to fix dual setpoint, F/C conversion,
+##        and expose Mitsubishi-specific features (horizontal vane) via standard HA APIs.
+## Deps: homeassistant.components.climate, homeassistant.helpers.event
+
 import logging
 from typing import Any, List, Optional
 import voluptuous as vol
@@ -29,11 +34,13 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 _LOGGER = logging.getLogger(__name__)
 
 CONF_SOURCE_ENTITY = "source_entity"
+CONF_HORIZONTAL_VANE_ENTITY = "horizontal_vane_entity"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_SOURCE_ENTITY): cv.entity_id,
         vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_HORIZONTAL_VANE_ENTITY): cv.entity_id,
     }
 )
 
@@ -47,9 +54,13 @@ async def async_setup_platform(
     """Set up the Mitsubishi Hybrid Climate platform via YAML."""
     source_entity_id = config[CONF_SOURCE_ENTITY]
     name = config.get(CONF_NAME)
+    horizontal_vane_entity_id = config.get(CONF_HORIZONTAL_VANE_ENTITY)
 
     async_add_entities(
-        [MitsubishiHybridClimate(hass, name, source_entity_id)],
+        [MitsubishiHybridClimate(
+            hass, name, source_entity_id,
+            horizontal_vane_entity_id=horizontal_vane_entity_id,
+        )],
         True,
     )
 
@@ -67,15 +78,25 @@ async def async_setup_entry(
         source_entity_id = entry.data.get(CONF_SOURCE_ENTITY)
 
     name = entry.data.get(CONF_NAME)
+    horizontal_vane_entity_id = entry.data.get(CONF_HORIZONTAL_VANE_ENTITY)
 
     async_add_entities(
-        [MitsubishiHybridClimate(hass, name, source_entity_id, entry.entry_id)],
+        [MitsubishiHybridClimate(
+            hass, name, source_entity_id, entry.entry_id,
+            horizontal_vane_entity_id=horizontal_vane_entity_id,
+        )],
         True,
     )
 
 
 class MitsubishiHybridClimate(ClimateEntity):
-    """Representation of a Mitsubishi Hybrid Climate device."""
+    """Representation of a Mitsubishi Hybrid Climate device.
+
+    Wraps an ESPHome CN105 climate entity to provide:
+    - Adaptive single/dual setpoint based on current HVAC mode
+    - Fahrenheit normalisation (avoids double F→C conversion)
+    - Independent horizontal swing via HA 2024.12+ swing_horizontal_mode
+    """
 
     def __init__(
         self,
@@ -83,6 +104,7 @@ class MitsubishiHybridClimate(ClimateEntity):
         name: str | None,
         source_entity_id: str,
         unique_id: str | None = None,
+        horizontal_vane_entity_id: str | None = None,
     ) -> None:
         """Initialize the climate device."""
         super().__init__()
@@ -92,15 +114,28 @@ class MitsubishiHybridClimate(ClimateEntity):
         self._source_state = None
         self._attr_should_poll = False
         self._attr_unique_id = unique_id or f"{source_entity_id}_hybrid"
+        # Horizontal vane (WideVane) — optional select entity from ESPHome
+        self._horizontal_vane_entity_id = horizontal_vane_entity_id
+        self._horizontal_vane_state = None
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         # Get initial state
         self._source_state = self.hass.states.get(self._source_entity_id)
 
+        # Track source climate entity changes
+        tracked_entities = [self._source_entity_id]
+
+        # Track horizontal vane select entity changes (if configured)
+        if self._horizontal_vane_entity_id:
+            self._horizontal_vane_state = self.hass.states.get(
+                self._horizontal_vane_entity_id
+            )
+            tracked_entities.append(self._horizontal_vane_entity_id)
+
         self.async_on_remove(
             async_track_state_change_event(
-                self.hass, [self._source_entity_id], self._async_source_changed
+                self.hass, tracked_entities, self._async_source_changed
             )
         )
 
@@ -108,7 +143,13 @@ class MitsubishiHybridClimate(ClimateEntity):
     def _async_source_changed(self, event: Event) -> None:
         """Handle source entity state changes."""
         new_state = event.data.get("new_state")
-        self._source_state = new_state
+        entity_id = event.data.get("entity_id")
+
+        if entity_id == self._source_entity_id:
+            self._source_state = new_state
+        elif entity_id == self._horizontal_vane_entity_id:
+            self._horizontal_vane_state = new_state
+
         self.async_write_ha_state()
 
     @property
@@ -154,7 +195,15 @@ class MitsubishiHybridClimate(ClimateEntity):
         else:
             features |= ClimateEntityFeature.TARGET_TEMPERATURE
 
+        # Add independent horizontal swing support when a horizontal vane entity is configured
+        if self._horizontal_vane_entity_id:
+            features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
+
         return ClimateEntityFeature(features)
+
+    # ════════════════════════════════════════════════════════════════
+    # Temperature normalisation (F ↔ C)
+    # ════════════════════════════════════════════════════════════════
 
     @property
     def _source_unit(self) -> str:
@@ -207,6 +256,10 @@ class MitsubishiHybridClimate(ClimateEntity):
         always °C regardless of what the source entity advertises.
         """
         return UnitOfTemperature.CELSIUS
+
+    # ════════════════════════════════════════════════════════════════
+    # Temperature properties
+    # ════════════════════════════════════════════════════════════════
 
     @property
     def current_temperature(self) -> Optional[float]:
@@ -263,6 +316,10 @@ class MitsubishiHybridClimate(ClimateEntity):
                 self._source_state.attributes.get("target_temp_low")
             )
         return None
+
+    # ════════════════════════════════════════════════════════════════
+    # HVAC mode
+    # ════════════════════════════════════════════════════════════════
 
     @property
     def hvac_mode(self) -> HVACMode:
@@ -433,6 +490,10 @@ class MitsubishiHybridClimate(ClimateEntity):
             blocking=True,
         )
 
+    # ════════════════════════════════════════════════════════════════
+    # Fan mode (pass-through)
+    # ════════════════════════════════════════════════════════════════
+
     @property
     def fan_mode(self) -> Optional[str]:
         """Return the fan setting."""
@@ -456,6 +517,10 @@ class MitsubishiHybridClimate(ClimateEntity):
             blocking=True,
         )
 
+    # ════════════════════════════════════════════════════════════════
+    # Swing mode — vertical (pass-through from source climate)
+    # ════════════════════════════════════════════════════════════════
+
     @property
     def swing_mode(self) -> Optional[str]:
         """Return the swing setting."""
@@ -478,6 +543,86 @@ class MitsubishiHybridClimate(ClimateEntity):
             {"entity_id": self._source_entity_id, "swing_mode": swing_mode},
             blocking=True,
         )
+
+    # ════════════════════════════════════════════════════════════════
+    # Swing horizontal mode — WideVane (Mitsubishi-specific)
+    # Maps the ESPHome horizontal_vane_select entity to the HA-native
+    # swing_horizontal_mode API (available since HA 2024.12).
+    # ════════════════════════════════════════════════════════════════
+
+    @property
+    def swing_horizontal_mode(self) -> Optional[str]:
+        """Return the current horizontal vane (WideVane) position.
+
+        Reads from the configured ESPHome select entity for horizontal vane.
+        Returns None if no horizontal vane entity is configured or unavailable.
+        """
+        if not self._horizontal_vane_entity_id:
+            return None
+
+        if self._horizontal_vane_state is None:
+            self._horizontal_vane_state = self.hass.states.get(
+                self._horizontal_vane_entity_id
+            )
+
+        if (
+            self._horizontal_vane_state is None
+            or self._horizontal_vane_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+        ):
+            return None
+
+        return self._horizontal_vane_state.state
+
+    @property
+    def swing_horizontal_modes(self) -> Optional[List[str]]:
+        """Return the list of available horizontal vane positions.
+
+        Reads the options from the ESPHome select entity's 'options' attribute.
+        Falls back to a default Mitsubishi WideVane set if options are unavailable.
+        """
+        if not self._horizontal_vane_entity_id:
+            return None
+
+        if self._horizontal_vane_state is None:
+            self._horizontal_vane_state = self.hass.states.get(
+                self._horizontal_vane_entity_id
+            )
+
+        if self._horizontal_vane_state is not None:
+            options = self._horizontal_vane_state.attributes.get("options")
+            if options:
+                return list(options)
+
+        # Fallback: standard Mitsubishi WideVane options
+        return ["←←", "←", "|", "→", "→→", "←→", "SWING"]
+
+    async def async_set_swing_horizontal_mode(
+        self, swing_horizontal_mode: str
+    ) -> None:
+        """Set new horizontal vane (WideVane) position.
+
+        Forwards the command to the ESPHome select entity via the
+        select.select_option service.
+        """
+        if not self._horizontal_vane_entity_id:
+            _LOGGER.warning(
+                "Cannot set horizontal swing: no horizontal_vane_entity configured"
+            )
+            return
+
+        await self.hass.services.async_call(
+            "select",
+            "select_option",
+            {
+                "entity_id": self._horizontal_vane_entity_id,
+                "option": swing_horizontal_mode,
+            },
+            blocking=True,
+        )
+
+    # ════════════════════════════════════════════════════════════════
+    # Preset mode (pass-through)
+    # ════════════════════════════════════════════════════════════════
 
     @property
     def preset_mode(self) -> Optional[str]:
@@ -504,6 +649,10 @@ class MitsubishiHybridClimate(ClimateEntity):
             },
             blocking=True,
         )
+
+    # ════════════════════════════════════════════════════════════════
+    # Temperature bounds
+    # ════════════════════════════════════════════════════════════════
 
     @property
     def min_temp(self) -> float:

--- a/custom_components/mitsubishi_climate_proxy/config_flow.py
+++ b/custom_components/mitsubishi_climate_proxy/config_flow.py
@@ -1,16 +1,24 @@
+## config_flow.py — Config Flow for Mitsubishi Climate Proxy
+## Role: UI-based configuration wizard for adding proxy instances via HA integrations page.
+## Deps: homeassistant.config_entries, homeassistant.components.climate, homeassistant.components.select
+
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import CONF_NAME, CONF_SOURCE
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 
 from . import DOMAIN
+
+CONF_HORIZONTAL_VANE_ENTITY = "horizontal_vane_entity"
+
 
 class MitsubishiHybridConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Mitsubishi Hybrid Climate."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
@@ -31,9 +39,19 @@ class MitsubishiHybridConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ent.entity_id for ent in self.hass.states.async_all(CLIMATE_DOMAIN)
         ]
 
+        # Get list of select entities (for horizontal vane)
+        select_entities = [
+            ent.entity_id for ent in self.hass.states.async_all(SELECT_DOMAIN)
+        ]
+        # Add empty option for "no horizontal vane"
+        select_entities_with_none = [""] + select_entities
+
         data_schema = vol.Schema({
             vol.Required(CONF_SOURCE): vol.In(climate_entities),
             vol.Optional(CONF_NAME): str,
+            vol.Optional(CONF_HORIZONTAL_VANE_ENTITY): vol.In(
+                select_entities_with_none
+            ),
         })
 
         return self.async_show_form(

--- a/custom_components/mitsubishi_climate_proxy/manifest.json
+++ b/custom_components/mitsubishi_climate_proxy/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "mitsubishi_climate_proxy",
     "name": "Mitsubishi Climate Proxy",
-    "version": "2026.5.1",
+    "version": "2026.5.2",
     "documentation": "https://github.com/echavet/MitsubishiCN105ESPHome",
     "dependencies": [],
     "codeowners": [

--- a/custom_components/mitsubishi_climate_proxy/strings.json
+++ b/custom_components/mitsubishi_climate_proxy/strings.json
@@ -3,10 +3,11 @@
     "step": {
       "user": {
         "title": "Add Mitsubishi Climate Proxy",
-        "description": "Create a hybrid entity (Dual/Single setpoint wrapper)",
+        "description": "Create a hybrid entity with Dual/Single setpoint wrapper and optional horizontal vane (WideVane) control.",
         "data": {
           "source": "Source Entity (ESPHome Climate)",
-          "name": "Name for the new Hybrid Entity"
+          "name": "Name for the new Hybrid Entity",
+          "horizontal_vane_entity": "Horizontal Vane Entity (ESPHome Select, optional)"
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds independent **horizontal vane (WideVane)** control to the `mitsubishi_climate_proxy` custom component by leveraging the HA-native `swing_horizontal_mode` API (available since **Home Assistant 2024.12**).

## What changed

### `climate.py`
- New optional config: `horizontal_vane_entity` — points to the ESPHome `select` entity for horizontal vane
- Tracks state changes on both the source climate entity AND the horizontal vane entity
- Implements `swing_horizontal_mode`, `swing_horizontal_modes`, `async_set_swing_horizontal_mode`
- Adds `SWING_HORIZONTAL_MODE` to `supported_features` when a horizontal vane entity is configured
- Commands forwarded via `select.select_option` service

### `config_flow.py`
- Added `horizontal_vane_entity` field to the config flow UI (dropdown of available `select` entities)
- Config flow VERSION bumped to 2

### `strings.json`
- Added label for the new horizontal vane field

### `manifest.json`
- Version bumped to `2026.5.2`

### `README.md`
- Documented the new feature (YAML + UI configuration)
- Added "Horizontal Vane (WideVane)" section in "How it works"

## Architecture

```
ESPHome select.horizontal_vane  ←→  proxy.swing_horizontal_mode  ←→  HA Climate Card UI
         (state tracking)              (feature flag)                (standard swing_horizontal)
```

The proxy reads vane position from the ESPHome `select` entity and re-publishes it as the HA-native `swing_horizontal_mode`. This allows the WideVane to appear directly in the standard climate card.

## Requirements
- Home Assistant **2024.12+** (for `ClimateEntityFeature.SWING_HORIZONTAL_MODE`)
- ESPHome CN105 component with `horizontal_vane_select` configured

## Configuration example (YAML)
```yaml
climate:
  - platform: mitsubishi_climate_proxy
    source_entity: climate.salon_esphome
    name: Salon Climate
    horizontal_vane_entity: select.salon_horizontal_vane  # Optional
```