### PR TITLE
fix: resolve isUARTConnected_ compile error and false 0x80 error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,7 +939,7 @@ sensor:
     name: "dg_uart_connected"
     entity_category: DIAGNOSTIC
     lambda: |-
-      return (bool) id(hp).isUARTConnected_;
+      return (bool) id(hp).isUARTReady_();
     update_interval: 30s
   - platform: template
     name: "dg_complete_cycles"

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -412,11 +412,14 @@ void CN105Climate::getErrorInfoFromResponsePacket() {
     if (this->error_code_sensor_ != nullptr) {
         uint8_t error_raw = this->data[4];
         uint8_t error_sub = this->data[5];
-        if (error_raw == 0x00 && error_sub == 0x00) {
+        // Bit 7 (0x80) is a protocol status flag ("error reporting available"),
+        // not an actual error code. Use lower 7 bits for real error detection.
+        uint8_t error_code = error_raw & 0x7F;
+        if (error_code == 0x00 && error_sub == 0x00) {
             this->error_code_sensor_->publish_state("No Error");
         } else {
             char buf[32];
-            snprintf(buf, sizeof(buf), "Error 0x%02X sub 0x%02X", error_raw, error_sub);
+            snprintf(buf, sizeof(buf), "Error 0x%02X sub 0x%02X", error_code, error_sub);
             this->error_code_sensor_->publish_state(buf);
         }
     }


### PR DESCRIPTION
## Summary

Fixes two issues reported by users after the FSM refactoring.

### Issue #645 — Compile error with `isUARTConnected_`

The legacy boolean `isUARTConnected_` was removed during the DriverState FSM migration but the README diagnostic sensor example still referenced it. Users copying this example get a compilation error.

**Fix:** Updated `README.md` to use `isUARTReady_()` instead.

### Issue #646 — False positive `Error 0x80 sub 0x00`

The error info packet (0x04) uses bit 7 (`0x80`) as a protocol status flag meaning "error reporting available", not as an actual error code. When `data[4] = 0x80` and `data[5] = 0x00`, this should be treated as "No Error".

**Fix:** Mask bit 7 before checking the error code:
```cpp
uint8_t error_code = error_raw & 0x7F;
```

This correctly reports "No Error" for `0x80 sub 0x00` while still detecting real error codes in the lower 7 bits.

## Changes

| File | Change |
|------|--------|
| `README.md` | Replace `isUARTConnected_` → `isUARTReady_()` in diagnostic sensor example |
| `components/cn105/hp_readings.cpp` | Mask bit 7 in error code decoding |

Fixes #645, fixes #646