### PR TITLE
Fixed memory leak in CN105Climate::emulateMutex

### DIFF
--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -525,7 +525,8 @@ int CN105Climate::lookupByteMapValue(const int valuesMap[], const uint8_t byteMa
 void CN105Climate::emulateMutex(const char* retryName, std::function<void()>&& f) {
     auto callback = std::make_shared<std::function<void()>>(std::move(f));
     auto retry = std::make_shared<std::function<void(uint8_t, uint32_t)>>();
-    *retry = [this, retryName, retry, callback](uint8_t retry_count, uint32_t delay_ms) {
+    std::weak_ptr<std::function<void(uint8_t, uint32_t)>> weak_retry = retry;
+    *retry = [this, retryName, weak_retry, callback](uint8_t retry_count, uint32_t delay_ms) {
         if (this->wantedSettingsMutex) {
             if (retry_count >= 10) {
                 ESP_LOGW(retryName, "10 retry calls failed because mutex was locked, forcing unlock...");
@@ -536,9 +537,11 @@ void CN105Climate::emulateMutex(const char* retryName, std::function<void()>&& f
             }
             ESP_LOGI(retryName, "wantedSettingsMutex is already locked, defferring...");
             const uint32_t next_delay_ms = static_cast<uint32_t>(delay_ms * 1.2f);
-            this->set_timeout(retryName, delay_ms, [retry, retry_count, next_delay_ms]() {
-                (*retry)(retry_count + 1, next_delay_ms);
-            });
+            if (auto retry = weak_retry.lock()) {
+                this->set_timeout(retryName, delay_ms, [retry, retry_count, next_delay_ms]() {
+                    (*retry)(retry_count + 1, next_delay_ms);
+                });
+            }
             return;
         } else {
             this->wantedSettingsMutex = true;
@@ -556,7 +559,8 @@ void CN105Climate::emulateMutex(const char* retryName, std::function<void()>&& f
 void CN105Climate::testEmulateMutex(const char* retryName, std::function<void()>&& f) {
     auto callback = std::make_shared<std::function<void()>>(std::move(f));
     auto retry = std::make_shared<std::function<void(uint8_t, uint32_t)>>();
-    *retry = [this, retryName, retry, callback](uint8_t retry_count, uint32_t delay_ms) {
+    std::weak_ptr<std::function<void(uint8_t, uint32_t)>> weak_retry = retry;
+    *retry = [this, retryName, weak_retry, callback](uint8_t retry_count, uint32_t delay_ms) {
         if (this->esp8266Mutex) {
             if (retry_count >= 10) {
                 ESP_LOGW(retryName, "10 retry calls failed because mutex was locked, forcing unlock...");
@@ -567,9 +571,11 @@ void CN105Climate::testEmulateMutex(const char* retryName, std::function<void()>
             }
             ESP_LOGI(retryName, "testMutex is already locked, defferring...");
             const uint32_t next_delay_ms = static_cast<uint32_t>(delay_ms * 1.2f);
-            this->set_timeout(retryName, delay_ms, [retry, retry_count, next_delay_ms]() {
-                (*retry)(retry_count + 1, next_delay_ms);
-            });
+            if (auto retry = weak_retry.lock()) {
+                this->set_timeout(retryName, delay_ms, [retry, retry_count, next_delay_ms]() {
+                    (*retry)(retry_count + 1, next_delay_ms);
+                });
+            }
             return;
         } else {
             this->esp8266Mutex = true;


### PR DESCRIPTION
I noticed my ESP8266 running out of heap memory and crashing at regular intervals. This only happens when `ClimateCall`s are being issued.

The `retry` callback was stored in a `shared_ptr<std::function<...>>` and also captured that same `shared_ptr`, creating a reference cycle that prevented cleanup after the retry chain completed. The callback now captures a `weak_ptr` instead, and each scheduled timeout temporarily captures a strong `shared_ptr` so the retry function remains alive only while a retry is pending.

Yes I know I should upgrade to an ESP32 but I've already soldered this one and installed it in the unit and it's been working fine for years with previous iterations of this project. I discovered this issue after not upgrading the firmware in a long time.