### PR TITLE
Update readme to include more units with confirmed outdoor temp

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,9 @@ Compatible units (as reported by users):
 | MSZ-FSxxNA     | MXZ-4C36NA2      | Works                              |
 |                | MUZ-FD25NA       | Not working                        |
 | MSZ-LN35       | MUZ-LN35         | Not working                        |
+| MSZ-LN50       | MXZ-2F53VFHZ     | Works                              |
+| MSZ-KT25       | MXZ-2F53VFHZ     | Works                              |
+| MSZ-LNxx       | MXZ-4F83VFHZ     | Works                              |
 | MSZ-AP20VGK    | MXZ-4F83VF       | Works                              |
 | MSZ-FT50VG2    | MUZ-FT50VG       | Works                              |
 


### PR DESCRIPTION
I have two outdoor units, coupled with several indoor units. All of these report the outdoor temperature via this component. This commit adds these units to the README.