### PR TITLE
Fix #673: HEAT_COOL band corrupted under fahrenheit_compatibility (don't re-derive the band from the transmitted setpoint)

### DIFF
--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -113,8 +113,14 @@ void CN105Climate::updateTargetTemperaturesFromSettings(float temperature) {
             if (std::isnan(this->getTargetTemperatureLow())) {
                 this->setTargetTemperatureLow(temperature);
             }
-        } else if (this->mode == climate::CLIMATE_MODE_AUTO) {
-            // En AUTO: si les deux bornes existent déjà, ne pas recentrer
+        } else if (this->mode == climate::CLIMATE_MODE_AUTO || this->mode == climate::CLIMATE_MODE_HEAT_COOL) {
+            // En AUTO/HEAT_COOL: si les deux bornes existent déjà, ne pas recentrer.
+            // In HEAT_COOL the transmitted setpoint is the deadband output
+            // clamp(current, low, high) — it carries no information about the
+            // band, so reconstructing the band from it corrupts the user's
+            // setpoints (issue #673: with fahrenheit_compatibility the
+            // non-idempotent table round-trip ratchets the band +0.5°C per
+            // pass until it parks 1.0°C above the requested values).
             bool lowDefined = !std::isnan(this->getTargetTemperatureLow());
             bool highDefined = !std::isnan(this->getTargetTemperatureHigh());
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -37,6 +37,8 @@ add_executable(cn105_tests
     test_real_frames.cpp
     test_frame_parser.cpp
     test_protocol.cpp
+    test_localization.cpp
+    test_dual_setpoint_recenter.cpp
 )
 
 target_link_libraries(cn105_tests

--- a/tests/unit/test_dual_setpoint_recenter.cpp
+++ b/tests/unit/test_dual_setpoint_recenter.cpp
@@ -1,0 +1,265 @@
+/// test_dual_setpoint_recenter.cpp — Regression tests for issue #673:
+/// HEAT_COOL dual-setpoint band must never be re-derived from the transmitted
+/// single setpoint.
+/// Deps: localization.h (production), esphome_stubs.h
+///
+/// Pattern: standalone reimplementation of the band logic around the PRODUCTION
+/// FahrenheitSupport class (same approach as test_calculate_temp.cpp), with
+/// `this->mode` replaced by a parameter. Mirrors:
+///   - the get/set target-temperature wrappers (utils.cpp): every store crosses
+///     HP→UI, every read crosses UI→HP through the Fahrenheit table;
+///   - calculateTemperatureSetting (utils.cpp, encoding B);
+///   - the HEAT_COOL deadband from controlTemperature (climateControls.cpp):
+///     in-band → transmitted setpoint = current room temperature;
+///   - updateTargetTemperaturesFromSettings (utils.cpp) dispatch, both the
+///     FIXED version (AUTO and HEAT_COOL preserve the band) and the PRE-FIX
+///     version (HEAT_COOL falls into the generic recentring else-branch) so the
+///     ratchet itself is demonstrated and pinned.
+///
+/// Hardware-observed bug (issue #673, fahrenheit_compatibility "standard",
+/// encoding B): band 61/82°F crept to 62/83 then 63/84 (requested +1.0°C in two
+/// +0.5°C passes, width preserved); 65/71°F was coincidentally stable.
+#include <gtest/gtest.h>
+#include <cmath>
+#include "esphome_stubs.h"
+#include "localization.h"
+
+using esphome::FahrenheitMode;
+using esphome::FahrenheitSupport;
+
+namespace {
+
+enum class Mode { HEAT, COOL, DRY, AUTO, HEAT_COOL };
+
+// Mirror of calculateTemperatureSetting (utils.cpp), encoding B
+float calcSettingB(float s) {
+    s = std::round(2.0f * s) / 2.0f;
+    return s < 10.0f ? 10.0f : (s > 31.0f ? 31.0f : s);
+}
+
+struct BandSim {
+    FahrenheitSupport fahr;
+    // ESPHome base-class storage is UI-Celsius
+    float low_ui = NAN;
+    float high_ui = NAN;
+
+    // Mirrors of setTargetTemperatureLow/High (utils.cpp): store HP→UI
+    void setLow(float hp) { low_ui = fahr.normalizeHeatpumpTemperatureToUiTemperature(hp); }
+    void setHigh(float hp) { high_ui = fahr.normalizeHeatpumpTemperatureToUiTemperature(hp); }
+    // Mirrors of getTargetTemperatureLow/High (utils.cpp): read UI→HP
+    float getLow() { return fahr.normalizeUiTemperatureToHeatpumpTemperature(low_ui); }
+    float getHigh() { return fahr.normalizeUiTemperatureToHeatpumpTemperature(high_ui); }
+
+    // Mirror of the user write path: processTemperatureChange converts the
+    // ClimateCall UI values to HP space, handleDualSetpointBoth stores them.
+    void userSetsBandF(int lowF, int highF) {
+        const float lowHp = fahr.normalizeUiTemperatureToHeatpumpTemperature((lowF - 32.0f) / 1.8f);
+        const float highHp = fahr.normalizeUiTemperatureToHeatpumpTemperature((highF - 32.0f) / 1.8f);
+        setLow(lowHp);
+        setHigh(highHp);
+    }
+
+    // Mirror of the controlTemperature HEAT_COOL deadband (climateControls.cpp)
+    float deadband(float currentHp) {
+        const float lo = getLow();
+        const float hi = getHigh();
+        if (currentHp < lo) return lo;
+        if (currentHp > hi) return hi;
+        return currentHp;
+    }
+
+    // Mirror of updateTargetTemperaturesFromSettings (utils.cpp) — FIXED
+    // dispatch: AUTO and HEAT_COOL both take the band-preserving branch.
+    void updateFromSettingsFixed(Mode mode, float temperature) {
+        updateFromSettings(mode, temperature, /*heatCoolPreserves=*/true);
+    }
+
+    // PRE-FIX dispatch: HEAT_COOL falls through to the recentring else-branch.
+    void updateFromSettingsPreFix(Mode mode, float temperature) {
+        updateFromSettings(mode, temperature, /*heatCoolPreserves=*/false);
+    }
+
+private:
+    void updateFromSettings(Mode mode, float temperature, bool heatCoolPreserves) {
+        const bool preserving =
+            (mode == Mode::AUTO) || (mode == Mode::HEAT_COOL && heatCoolPreserves);
+        if (mode == Mode::HEAT) {
+            setLow(temperature);
+            if (std::isnan(getHigh())) setHigh(temperature);
+        } else if (mode == Mode::COOL || mode == Mode::DRY) {
+            setHigh(temperature);
+            if (std::isnan(getLow())) setLow(temperature);
+        } else if (preserving) {
+            const bool lowDefined = !std::isnan(getLow());
+            const bool highDefined = !std::isnan(getHigh());
+            if (lowDefined && highDefined) {
+                // keep dual setpoints
+            } else if (lowDefined) {
+                setHigh(getLow() + 2.0f);
+            } else if (highDefined) {
+                setLow(getHigh() - 2.0f);
+            } else {
+                setLow(temperature - 2.0f);
+                setHigh(temperature + 2.0f);
+            }
+        } else {
+            // generic else-branch (the pre-fix HEAT_COOL path): recentre the
+            // band around the quantized median when it differs from the
+            // reported/sent setpoint.
+            if (std::isnan(getLow())) setLow(temperature);
+            if (std::isnan(getHigh())) setHigh(temperature);
+            const float theoretical = calcSettingB((getLow() + getHigh()) / 2.0f);
+            if (theoretical != temperature) {
+                const float delta = (getHigh() - getLow()) / 2.0f;
+                setLow(theoretical - delta);
+                setHigh(theoretical + delta);
+            }
+        }
+    }
+};
+
+// One full firmware pass: the write-path publish + the read-path settings sync
+// both call updateTargetTemperaturesFromSettings with the deadband value.
+void runFixedPasses(BandSim& sim, float currentHp, int passes) {
+    for (int i = 0; i < passes; ++i) {
+        const float sent = calcSettingB(sim.deadband(currentHp));
+        sim.updateFromSettingsFixed(Mode::HEAT_COOL, sent);  // write path
+        sim.updateFromSettingsFixed(Mode::HEAT_COOL, sent);  // read path
+    }
+}
+
+int displayedF(float ui) { return static_cast<int>(std::lround(ui * 1.8f + 32.0f)); }
+
+}  // namespace
+
+// ========================================================
+// The #673 repro: band 61/82°F, room 66°F (in-band), STANDARD table.
+// With the fix the band must not move — pre-fix it crept to 63/84.
+// ========================================================
+
+TEST(DualSetpointRecenterTest, HeatCool_Standard_61_82F_BandNeverMoves) {
+    BandSim sim;
+    sim.fahr.setUseFahrenheitSupportMode(FahrenheitMode::STANDARD);
+    sim.userSetsBandF(61, 82);
+    const float low0 = sim.getLow();
+    const float high0 = sim.getHigh();
+
+    runFixedPasses(sim, /*current 66F=*/18.5f, /*passes=*/3);
+
+    EXPECT_FLOAT_EQ(sim.getLow(), low0);
+    EXPECT_FLOAT_EQ(sim.getHigh(), high0);
+    EXPECT_EQ(displayedF(sim.low_ui), 61);
+    EXPECT_EQ(displayedF(sim.high_ui), 82);
+}
+
+TEST(DualSetpointRecenterTest, HeatCool_Alt_61_82F_BandNeverMoves) {
+    BandSim sim;
+    sim.fahr.setUseFahrenheitSupportMode(FahrenheitMode::ALT);
+    sim.userSetsBandF(61, 82);
+    const float low0 = sim.getLow();
+    const float high0 = sim.getHigh();
+
+    runFixedPasses(sim, 18.5f, 3);
+
+    EXPECT_FLOAT_EQ(sim.getLow(), low0);
+    EXPECT_FLOAT_EQ(sim.getHigh(), high0);
+}
+
+TEST(DualSetpointRecenterTest, HeatCool_CelsiusOff_BandNeverMoves) {
+    BandSim sim;
+    sim.fahr.setUseFahrenheitSupportMode(FahrenheitMode::OFF);
+    sim.low_ui = 16.0f;
+    sim.high_ui = 27.5f;
+
+    runFixedPasses(sim, 18.5f, 3);
+
+    EXPECT_FLOAT_EQ(sim.getLow(), 16.0f);
+    EXPECT_FLOAT_EQ(sim.getHigh(), 27.5f);
+}
+
+TEST(DualSetpointRecenterTest, HeatCool_Standard_65_71F_StaysExact) {
+    BandSim sim;
+    sim.fahr.setUseFahrenheitSupportMode(FahrenheitMode::STANDARD);
+    sim.userSetsBandF(65, 71);
+
+    runFixedPasses(sim, 18.5f, 3);
+
+    EXPECT_EQ(displayedF(sim.low_ui), 65);
+    EXPECT_EQ(displayedF(sim.high_ui), 71);
+}
+
+// Deadband edge: current temperature outside the band transmits a bound; the
+// band itself must still not move.
+TEST(DualSetpointRecenterTest, HeatCool_Standard_OutOfBandCurrent_BandNeverMoves) {
+    BandSim sim;
+    sim.fahr.setUseFahrenheitSupportMode(FahrenheitMode::STANDARD);
+    sim.userSetsBandF(61, 82);
+    const float low0 = sim.getLow();
+    const float high0 = sim.getHigh();
+
+    runFixedPasses(sim, /*current 55F, below band=*/12.8f, 3);
+
+    EXPECT_FLOAT_EQ(sim.getLow(), low0);
+    EXPECT_FLOAT_EQ(sim.getHigh(), high0);
+}
+
+// ========================================================
+// Behavior of the other modes is unchanged by the fix.
+// ========================================================
+
+TEST(DualSetpointRecenterTest, LegacyAuto_KeepsDefinedBand) {
+    BandSim sim;
+    sim.fahr.setUseFahrenheitSupportMode(FahrenheitMode::STANDARD);
+    sim.userSetsBandF(65, 75);
+    const float low0 = sim.getLow();
+    const float high0 = sim.getHigh();
+
+    sim.updateFromSettingsFixed(Mode::AUTO, 21.0f);
+
+    EXPECT_FLOAT_EQ(sim.getLow(), low0);
+    EXPECT_FLOAT_EQ(sim.getHigh(), high0);
+}
+
+TEST(DualSetpointRecenterTest, Heat_AssignsLowDirectly) {
+    BandSim sim;
+    sim.fahr.setUseFahrenheitSupportMode(FahrenheitMode::STANDARD);
+    sim.userSetsBandF(61, 82);
+
+    sim.updateFromSettingsFixed(Mode::HEAT, 18.0f);  // unit reports 18.0C (65F)
+
+    EXPECT_NEAR(sim.getLow(), 18.0f, 1e-4f);
+}
+
+TEST(DualSetpointRecenterTest, HeatCool_NaNBounds_InitializedAroundSetpoint) {
+    BandSim sim;
+    sim.fahr.setUseFahrenheitSupportMode(FahrenheitMode::OFF);
+
+    sim.updateFromSettingsFixed(Mode::HEAT_COOL, 21.0f);
+
+    EXPECT_FLOAT_EQ(sim.getLow(), 19.0f);
+    EXPECT_FLOAT_EQ(sim.getHigh(), 23.0f);
+}
+
+// ========================================================
+// The ratchet itself, pinned: with the PRE-FIX dispatch the same scenario
+// creeps +0.5°C per pass on both bounds (this is what issue #673 observed
+// on hardware as 61/82 → 62/83 → 63/84). If this test ever fails, the
+// mirror has drifted from the analysis — re-verify against utils.cpp.
+// ========================================================
+
+TEST(DualSetpointRecenterTest, PreFixDispatch_DemonstratesTheRatchet) {
+    BandSim sim;
+    sim.fahr.setUseFahrenheitSupportMode(FahrenheitMode::STANDARD);
+    sim.userSetsBandF(61, 82);
+    const float low0 = sim.getLow();    // 16.0
+    const float high0 = sim.getHigh();  // 27.5
+
+    const float sent = calcSettingB(sim.deadband(18.5f));  // in-band → 18.5
+    sim.updateFromSettingsPreFix(Mode::HEAT_COOL, sent);   // write-path pass
+    sim.updateFromSettingsPreFix(Mode::HEAT_COOL, sent);   // read-path pass
+
+    EXPECT_NEAR(sim.getLow(), low0 + 1.0f, 1e-3f);    // 61F → 63F
+    EXPECT_NEAR(sim.getHigh(), high0 + 1.0f, 1e-3f);  // 82F → 84F
+    EXPECT_EQ(displayedF(sim.low_ui), 63);
+    EXPECT_EQ(displayedF(sim.high_ui), 84);
+}

--- a/tests/unit/test_localization.cpp
+++ b/tests/unit/test_localization.cpp
@@ -1,0 +1,120 @@
+/// test_localization.cpp — Tests for FahrenheitSupport (localization.h, production code)
+/// Deps: localization.h, esphome_stubs.h
+///
+/// Context (issue #673): the Fahrenheit table conversions are applied on every
+/// target-temperature store (HP→UI) and read (UI→HP). These tests pin down the
+/// invariant the rest of the firmware relies on: the storage round-trip cycle
+/// hpToUi(uiToHp(u)) is STABLE for any UI value that itself came from the table
+/// (i.e. set(get(x)) never drifts once a value has been through one cycle).
+/// Note: uiToHp is deliberately NOT idempotent on arbitrary inputs (table-Celsius
+/// values such as 22.5°C sit exactly halfway between two Fahrenheit rows), which
+/// is why feeding derived values back through the table — as the pre-#673-fix
+/// band recentring did — can ratchet. The fix avoids re-deriving the band, and
+/// these tests guarantee the benign cycle stays benign.
+#include <gtest/gtest.h>
+#include <cmath>
+#include "esphome_stubs.h"
+#include "localization.h"
+
+using esphome::FahrenheitMode;
+using esphome::FahrenheitSupport;
+
+namespace {
+
+float uiFromF(int f) { return (static_cast<float>(f) - 32.0f) / 1.8f; }
+
+}  // namespace
+
+// ========================================================
+// OFF mode: conversions are identity
+// ========================================================
+
+TEST(FahrenheitSupportTest, OffMode_Passthrough) {
+    FahrenheitSupport fs;
+    fs.setUseFahrenheitSupportMode(FahrenheitMode::OFF);
+    for (float c = 10.0f; c <= 31.0f; c += 0.25f) {
+        EXPECT_FLOAT_EQ(fs.normalizeUiTemperatureToHeatpumpTemperature(c), c);
+        EXPECT_FLOAT_EQ(fs.normalizeHeatpumpTemperatureToUiTemperature(c), c);
+    }
+}
+
+// ========================================================
+// Storage round-trip cycle: for every whole-Fahrenheit UI value,
+// one get/set cycle returns the same UI value (no drift), and a
+// second cycle is a fixed point.
+// ========================================================
+
+static void expectCycleStable(FahrenheitMode mode) {
+    FahrenheitSupport fs;
+    fs.setUseFahrenheitSupportMode(mode);
+    for (int f = 61; f <= 88; ++f) {
+        const float u0 = uiFromF(f);
+        const float hp = fs.normalizeUiTemperatureToHeatpumpTemperature(u0);
+        const float u1 = fs.normalizeHeatpumpTemperatureToUiTemperature(hp);
+        EXPECT_NEAR(u1, u0, 1e-3f) << "first cycle drifted for " << f << "F";
+
+        const float hp2 = fs.normalizeUiTemperatureToHeatpumpTemperature(u1);
+        const float u2 = fs.normalizeHeatpumpTemperatureToUiTemperature(hp2);
+        EXPECT_NEAR(u2, u1, 1e-4f) << "second cycle drifted for " << f << "F";
+    }
+}
+
+TEST(FahrenheitSupportTest, StandardTable_StorageCycleStable) {
+    expectCycleStable(FahrenheitMode::STANDARD);
+}
+
+TEST(FahrenheitSupportTest, AltTable_StorageCycleStable) {
+    expectCycleStable(FahrenheitMode::ALT);
+}
+
+// ========================================================
+// Table-row Celsius values survive a store (HP→UI) and read back
+// (UI→HP) unchanged — the unit talks in these values.
+// ========================================================
+
+static void expectRowValuesRoundTrip(FahrenheitMode mode, const float* rows, int n) {
+    FahrenheitSupport fs;
+    fs.setUseFahrenheitSupportMode(mode);
+    for (int i = 0; i < n; ++i) {
+        const float ui = fs.normalizeHeatpumpTemperatureToUiTemperature(rows[i]);
+        const float back = fs.normalizeUiTemperatureToHeatpumpTemperature(ui);
+        EXPECT_NEAR(back, rows[i], 1e-4f) << "row value " << rows[i] << "C did not round-trip";
+    }
+}
+
+TEST(FahrenheitSupportTest, StandardTable_RowValuesRoundTrip) {
+    // Interior rows of the STANDARD table (61F/88F edges bypass the table by
+    // design — upper_bound edge — and are covered by the cycle tests above).
+    const float rows[] = {16.5f, 17.0f, 17.5f, 18.0f, 18.5f, 19.0f, 20.0f, 21.0f,
+                          21.5f, 22.0f, 22.5f, 23.0f, 24.0f, 25.0f, 26.0f, 27.0f,
+                          27.5f, 28.0f, 28.5f, 29.0f, 29.5f, 30.0f};
+    expectRowValuesRoundTrip(FahrenheitMode::STANDARD, rows, sizeof(rows) / sizeof(rows[0]));
+}
+
+TEST(FahrenheitSupportTest, AltTable_RowValuesRoundTrip) {
+    const float rows[] = {16.5f, 17.0f, 18.0f, 18.5f, 19.0f, 19.5f, 20.0f, 20.5f,
+                          21.0f, 21.5f, 22.0f, 23.0f, 24.0f, 25.0f, 26.0f, 27.0f,
+                          28.0f, 28.5f, 29.0f, 29.5f, 30.0f, 30.5f};
+    expectRowValuesRoundTrip(FahrenheitMode::ALT, rows, sizeof(rows) / sizeof(rows[0]));
+}
+
+// ========================================================
+// Documented non-idempotence of uiToHp on raw table-Celsius input:
+// 22.5C is exactly 72.5F, halfway between rows 72 and 73 — the lookup
+// must pick ONE of them deterministically. This is why derived values
+// must never be re-fed through the table (issue #673), and why the
+// cycle tests above are the correct invariant.
+// ========================================================
+
+TEST(FahrenheitSupportTest, StandardTable_MidpointResolvesDeterministically) {
+    FahrenheitSupport fs;
+    fs.setUseFahrenheitSupportMode(FahrenheitMode::STANDARD);
+    const float once = fs.normalizeUiTemperatureToHeatpumpTemperature(22.5f);
+    const float twice = fs.normalizeUiTemperatureToHeatpumpTemperature(once);
+    // Whatever row the tie resolves to, the result must be a value from the
+    // table and the SECOND application through a storage cycle must be stable.
+    const float ui = fs.normalizeHeatpumpTemperatureToUiTemperature(once);
+    const float again = fs.normalizeUiTemperatureToHeatpumpTemperature(ui);
+    EXPECT_NEAR(again, once, 1e-4f);
+    (void)twice;
+}


### PR DESCRIPTION
Fixes #673.

### Root cause

`updateTargetTemperaturesFromSettings()` (utils.cpp) has band-handling branches for HEAT / COOL / DRY / AUTO — but none for `CLIMATE_MODE_HEAT_COOL`, so HEAT_COOL falls into the generic else-branch that **re-centres the user's band** around the quantized median whenever it differs from the reported/sent setpoint.

In HEAT_COOL the transmitted setpoint is the deadband output `clamp(current, low, high)` — room temperature when in-band — so it essentially never equals the band median and the recentre fires on every pass, from **both** call sites (write path `publishWantedSettingsStateToHA`, read path `publishStateToHA`).

The recentre is harmless in Celsius (≤0.25 °C one-time nudge), but with `fahrenheit_compatibility` enabled each endpoint write/read crosses the F-table conversions, which are **not idempotent on derived values**: `calculateTemperatureSetting` rounds an off-grid median up 0.25 °C, the recentred endpoints land exactly halfway between table rows, and the strict `<` tie-break in `normalizeHeatpumpTemperatureToUiTemperature` snaps both UP one F row. Net: **+0.5 °C on both bounds per pass, two passes per user action** → the band parks 1.0 °C above the requested values, width preserved. Bands whose median lands on the 0.5 °C grid (e.g. 65/71 °F) coincidentally survive, which is why this went unnoticed.

### Fix

One line: extend the existing band-preserving AUTO branch to also cover HEAT_COOL. That branch already implements exactly the right policy — keep both bounds when defined, fill a missing bound at ±2 °C, init around the reported value when both are missing (matching `controlTemperature`'s own HEAT_COOL init). The reported single setpoint carries no information about the band in HEAT_COOL, so reconstructing the band from it is semantically wrong in any unit system. No behavior change for HEAT/COOL/DRY/legacy-AUTO or Celsius users.

### Tests (180/180 pass)

- `test_localization.cpp` — pins the F-table storage-cycle stability invariants for both tables (the property the firmware relies on), OFF passthrough, and documents the midpoint determinism that powered the ratchet.
- `test_dual_setpoint_recenter.cpp` — mirrors the band logic around the **production** `FahrenheitSupport` (same pattern as `test_calculate_temp.cpp`): asserts the band never moves across multi-pass HEAT_COOL cycles (STANDARD/ALT/OFF, in-band and out-of-band current), legacy-AUTO/HEAT behavior unchanged, NaN-bounds init, plus a pinned demonstration of the pre-fix ratchet reproducing the hardware numbers (61/82 → 63/84 in exactly two passes).

### Hardware validation (2× MSZ wall units, ESP32, esp-idf, encoding B)

Before (1b09ccc, `fahrenheit_compatibility: "standard"`): `61/82 → 63/84` (creep), `62/70 → silently kept 62/65`. After (this branch, same config, same unit):

| requested °F | 12 s | 40 s |
|---|---|---|
| 61/82 | 61/82 | 61/82 |
| 61/64 | 61/64 | 61/64 |
| 62/70 | 62/70 | 62/70 |
| 65/71 | 65/71 | 65/71 |

The partial-update loss also disappeared — it was the recentre re-asserting the stale band over the optimistic UI.

### Follow-ups deliberately not in this PR

Defense-in-depth items surfaced during analysis, happy to file/PR separately if wanted: the read-path grace window is dead code (`wantedSettings.resetSettings()` clears `hasBeenSent` immediately after send, so `RECEIVED_SETPOINT_GRACE_WINDOW_MS` is never effective); `currentSettings.dual_low_target/dual_high_target` are write-only; `c == NAN` comparisons in localization.h are always false; the F-table tie-break could be made idempotent for midpoints; with this fix, setpoint changes made at an IR remote while in hardware AUTO no longer move the HA band (arguably correct — the previous behavior corrupted it — but worth a release-note line).
