### PR TITLE
Fix: HEAT_COOL silently dropped when hardware-AUTO reports operating direction (HEAT/COOL)

### DIFF
--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -779,11 +779,27 @@ void CN105Climate::checkPowerAndModeSettings(heatpumpSettings& settings, bool up
         }
         if (strcmp(settings.power, "ON") == 0) {
             if (strcmp(settings.mode, "HEAT") == 0) {
-                this->mode = climate::CLIMATE_MODE_HEAT;
+                // A dual-setpoint unit driven in HEAT_COOL runs the heat pump in
+                // hardware AUTO, and the unit reports its *active operating
+                // direction* ("HEAT" here) back in the settings packet. Letting
+                // that overwrite this->mode silently drops the user out of
+                // HEAT_COOL and collapses the dual band to a single setpoint
+                // (updateTargetTemperaturesFromSettings then runs single-setpoint).
+                // Keep HEAT_COOL; the operating direction is surfaced separately
+                // by the auto_sub_mode sensor.
+                if (!(this->supports_dual_setpoint_ &&
+                      this->mode == climate::CLIMATE_MODE_HEAT_COOL)) {
+                    this->mode = climate::CLIMATE_MODE_HEAT;
+                }
             } else if (strcmp(settings.mode, "DRY") == 0) {
                 this->mode = climate::CLIMATE_MODE_DRY;
             } else if (strcmp(settings.mode, "COOL") == 0) {
-                this->mode = climate::CLIMATE_MODE_COOL;
+                // Same as the HEAT branch: hardware AUTO reports "COOL" as the
+                // active operating direction; don't let it clobber HEAT_COOL.
+                if (!(this->supports_dual_setpoint_ &&
+                      this->mode == climate::CLIMATE_MODE_HEAT_COOL)) {
+                    this->mode = climate::CLIMATE_MODE_COOL;
+                }
                 /*if (cool_setpoint != currentSettings.temperature) {
                     cool_setpoint = currentSettings.temperature;
                     save(currentSettings.temperature, cool_storage);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(cn105_tests
     test_real_frames.cpp
     test_frame_parser.cpp
     test_protocol.cpp
+    test_mode_preservation.cpp
 )
 
 target_link_libraries(cn105_tests

--- a/tests/unit/test_mode_preservation.cpp
+++ b/tests/unit/test_mode_preservation.cpp
@@ -1,0 +1,115 @@
+/// test_mode_preservation.cpp — Regression tests for the HEAT_COOL mode-clobber
+/// bug in checkPowerAndModeSettings (components/cn105/hp_readings.cpp).
+///
+/// Bug: a dual-setpoint unit driven in HEAT_COOL runs the heat pump in hardware
+/// AUTO; the unit then reports its *active operating direction* ("HEAT"/"COOL")
+/// in the settings packet. The unguarded HEAT/COOL branches used to overwrite
+/// this->mode, dropping the user out of HEAT_COOL and collapsing the dual band.
+/// Only the AUTO branch was guarded. The fix guards HEAT and COOL the same way,
+/// gated on supports_dual_setpoint_ so genuine single-setpoint builds are
+/// unaffected.
+///
+/// Pattern: standalone reimplementation of the mode-selection ladder (same
+/// approach as test_calculate_temp.cpp / test_real_frames.cpp), parameterised on
+/// (power, reportedMode, currentMode, supportsDual). The production code is a
+/// method on the full CN105Climate object and the gtest mocks do not define
+/// esphome::climate::ClimateMode, so a local enum mirror is used. This mirror is
+/// kept byte-faithful to the production ladder below it.
+#include <gtest/gtest.h>
+#include <cstring>
+
+namespace {
+
+enum class Mode { OFF, HEAT, COOL, DRY, FAN_ONLY, AUTO, HEAT_COOL };
+
+// Mirror of CN105Climate::checkPowerAndModeSettings()'s mode ladder
+// (hp_readings.cpp). `current` is this->mode on entry; the return value is
+// this->mode on exit.
+Mode resolveMode(const char* power, const char* reported,
+                 Mode current, bool supportsDual) {
+    if (std::strcmp(power, "ON") != 0) {
+        return Mode::OFF;
+    }
+    const bool holdHeatCool =
+        supportsDual && current == Mode::HEAT_COOL;
+    if (std::strcmp(reported, "HEAT") == 0) {
+        return holdHeatCool ? current : Mode::HEAT;
+    } else if (std::strcmp(reported, "DRY") == 0) {
+        return Mode::DRY;
+    } else if (std::strcmp(reported, "COOL") == 0) {
+        return holdHeatCool ? current : Mode::COOL;
+    } else if (std::strcmp(reported, "FAN") == 0) {
+        return Mode::FAN_ONLY;
+    } else if (std::strcmp(reported, "AUTO") == 0) {
+        // Pre-existing guard: stay in HEAT_COOL even if HP says AUTO.
+        return current == Mode::HEAT_COOL ? current : Mode::AUTO;
+    }
+    // Unknown mode: production logs a warning and leaves this->mode unchanged.
+    return current;
+}
+
+}  // namespace
+
+// ── The bug repro: in HEAT_COOL, a reported operating direction must not flip us ──
+
+TEST(ModePreservationTest, HeatCool_Preserved_WhenUnitReportsCool) {
+    EXPECT_EQ(resolveMode("ON", "COOL", Mode::HEAT_COOL, /*dual=*/true),
+              Mode::HEAT_COOL);
+}
+
+TEST(ModePreservationTest, HeatCool_Preserved_WhenUnitReportsHeat) {
+    EXPECT_EQ(resolveMode("ON", "HEAT", Mode::HEAT_COOL, /*dual=*/true),
+              Mode::HEAT_COOL);
+}
+
+TEST(ModePreservationTest, HeatCool_Preserved_WhenUnitReportsAuto) {
+    // Pins the pre-existing AUTO guard.
+    EXPECT_EQ(resolveMode("ON", "AUTO", Mode::HEAT_COOL, /*dual=*/true),
+              Mode::HEAT_COOL);
+}
+
+// ── A genuine user COOL/HEAT command still applies ──
+// (processModeChange sets this->mode before this read-path runs, and the
+// read-path is skipped entirely while a user demand is pending; once it clears,
+// current already equals the user's chosen mode, so the guard does not trap it.)
+
+TEST(ModePreservationTest, UserCool_StillApplies) {
+    EXPECT_EQ(resolveMode("ON", "COOL", Mode::COOL, /*dual=*/true),
+              Mode::COOL);
+}
+
+TEST(ModePreservationTest, UserHeat_StillApplies) {
+    EXPECT_EQ(resolveMode("ON", "HEAT", Mode::HEAT, /*dual=*/true),
+              Mode::HEAT);
+}
+
+// ── Single-setpoint builds are unaffected by the guard ──
+
+TEST(ModePreservationTest, SingleSetpointBuild_CoolApplies) {
+    EXPECT_EQ(resolveMode("ON", "COOL", Mode::HEAT_COOL, /*dual=*/false),
+              Mode::COOL);
+}
+
+TEST(ModePreservationTest, SingleSetpointBuild_HeatApplies) {
+    EXPECT_EQ(resolveMode("ON", "HEAT", Mode::HEAT_COOL, /*dual=*/false),
+              Mode::HEAT);
+}
+
+// ── Other modes / power unchanged ──
+
+TEST(ModePreservationTest, Dry_AppliesEvenFromHeatCool) {
+    EXPECT_EQ(resolveMode("ON", "DRY", Mode::HEAT_COOL, /*dual=*/true),
+              Mode::DRY);
+}
+
+TEST(ModePreservationTest, Fan_AppliesEvenFromHeatCool) {
+    EXPECT_EQ(resolveMode("ON", "FAN", Mode::HEAT_COOL, /*dual=*/true),
+              Mode::FAN_ONLY);
+}
+
+TEST(ModePreservationTest, PowerOff_AlwaysOff) {
+    EXPECT_EQ(resolveMode("OFF", "COOL", Mode::HEAT_COOL, /*dual=*/true),
+              Mode::OFF);
+    EXPECT_EQ(resolveMode("OFF", "HEAT", Mode::HEAT, /*dual=*/false),
+              Mode::OFF);
+}


### PR DESCRIPTION
## Summary

In `checkPowerAndModeSettings()` (`components/cn105/hp_readings.cpp`) only the **AUTO** branch guards against overwriting a user-selected `HEAT_COOL`. The **HEAT** and **COOL** branches do not, so a dual-setpoint unit can silently fall out of `HEAT_COOL` on the read path.

When a unit is driven in `HEAT_COOL`, the component sends hardware **AUTO** (see `controlMode()` in `climateControls.cpp`). A Mitsubishi unit in hardware AUTO reports its **active operating direction** (`"HEAT"` or `"COOL"`) back in the settings packet. The unguarded branches then set `this->mode = HEAT/COOL`, and the downstream `updateTargetTemperaturesFromSettings()` runs single-setpoint and **collapses the dual band to one setpoint** — the entity leaves dual-setpoint regulation and idles/overshoots outside the user's band.

## How I found this (code analysis, not an isolated hardware repro — being upfront)

I was debugging a real `heat_cool → cool` + band-collapse incident on my own install (two MSZ-class units, `dual_setpoint: true`, `fahrenheit_compatibility: "disabled"`, master `1b09ccc`). On closer inspection of the logbook, **that particular incident was triggered by an external `climate.set_hvac_mode` service call** (an anonymous, no-user call — most likely a HomeKit/cloud bridge re-asserting a cached accessory state), **not** by this read path. So I am **not** claiming a logged hardware reproduction isolated to this code path.

What I am claiming is narrower and, I think, still worth fixing: reading the code, the HEAT/COOL branches will produce the *same* end state (HEAT_COOL silently dropped, band collapsed) with no external command at all, the moment a hardware-AUTO unit reports its operating direction — and the AUTO branch right below already guards exactly this case, which reads as an oversight rather than intent. If you'd rather wait for a captured trace before merging, completely fair; I'll add one if I can reproduce it cleanly on the bench.

## Fix

Guard the HEAT and COOL branches the same way the AUTO branch already is, gated on `supports_dual_setpoint_` so single-setpoint builds are unaffected. The operating direction is still surfaced via the `auto_sub_mode` sensor, so no information is lost.

It should not trap a genuine user `COOL`/`HEAT`: a real mode change sets `this->mode` via `processModeChange()` *before* this read path runs, and `publishStateToHA()` skips the whole read path while `wantedSettings.mode/power` are pending — so on entry `this->mode` already equals the user's chosen mode and the guard does not fire. (Reviewers who know the FSM better than I do, please sanity-check that reasoning.)

## Tests

Adds `tests/unit/test_mode_preservation.cpp` (10 cases) mirroring the mode-selection ladder (same standalone pattern as the existing unit tests, since the mocks don't define `climate::ClimateMode`): `HEAT_COOL` preserved when the unit reports `COOL`/`HEAT`/`AUTO`; genuine user `COOL`/`HEAT` still apply; single-setpoint builds unaffected; power-off always off. These exercise a mirror of the ladder, not the production method directly. Full suite green (175/175) locally.

## Scope

Independent of #675 (Fahrenheit band re-centering) — this is a distinct mechanism (mode hold vs. °F-table creep) and reproduces with `fahrenheit_compatibility: "disabled"`. Adjacent to the proxy work in #674. Based directly on master `1b09ccc` so it can land on its own. Happy to drop the `supports_dual_setpoint_` term and key purely on `this->mode == HEAT_COOL` if you prefer.
