### PR TITLE
feat: persist HEAT_COOL dual-setpoint band across reboots (opt-in restore_setpoints)

### DIFF
--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -117,6 +117,7 @@ CONF_POWER_UNIT_IS_BTU = "power_unit_is_btu"
 
 # Support explicite du DUAL setpoint via YAML
 CONF_DUAL_SETPOINT = "dual_setpoint"
+CONF_RESTORE_SETPOINTS = "restore_setpoints"
 
 DEFAULT_CLIMATE_MODES = ["AUTO", "COOL", "HEAT", "DRY", "FAN_ONLY", "HEAT_COOL"]
 DEFAULT_FAN_MODES = ["AUTO", "MIDDLE", "QUIET", "LOW", "MEDIUM", "HIGH"]
@@ -446,6 +447,7 @@ CONFIG_SCHEMA = (
                         CONF_SWING_MODE, default=DEFAULT_SWING_MODES
                     ): cv.ensure_list(climate.validate_climate_swing_mode),
                     cv.Optional(CONF_DUAL_SETPOINT, default=False): cv.boolean,
+                    cv.Optional(CONF_RESTORE_SETPOINTS, default=False): cv.boolean,
                     cv.Optional(CONF_SUPPORTS_HORIZONTAL_VANE_MODE): cv.ensure_list(
                         cv.string
                     ),
@@ -527,6 +529,10 @@ def to_code(config):
             cg.add(traits.add_feature_flags(dual_flag))
 
         # Note: If yaml_dual is False, we simply do NOT add the dual_flag.
+
+        # Opt-in: persist the HEAT_COOL band (mode + low/high) to flash and restore
+        # it on boot, so a reboot/OTA doesn't drop the unit back to hardware AUTO.
+        cg.add(var.set_restore_setpoints(supports.get(CONF_RESTORE_SETPOINTS, False)))
         # ESPHome's default behavior for modes like COOL/HEAT is to enable single-point target temperature.
         # We don't need to explicitly force single-point or clear the dual flag (it's off by default).
 

--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -73,6 +73,11 @@ void CN105Climate::controlDelegate(const esphome::climate::ClimateCall& call) {
     updated = this->processSwingChange(call) || updated;
 
     this->finalizeControlIfUpdated(updated);
+
+    // Persist the (possibly new) mode + band so it can be restored after a reboot.
+    if (updated) {
+        this->save_setpoint_state_();
+    }
 }
 
 bool CN105Climate::processModeChange(const esphome::climate::ClimateCall& call) {
@@ -740,5 +745,56 @@ void CN105Climate::set_remote_temperature(float setting) {
     } else {
         // Stop keep-alive when reverting to internal sensor
         this->stopRemoteTempKeepAlive();
+    }
+}
+
+// --- HEAT_COOL band persistence (opt-in: supports.restore_setpoints) ----------------
+// The dual-setpoint band is synthetic (a Mitsubishi unit stores only a single setpoint),
+// so it is lost on reboot and the entity returns as hardware AUTO. When enabled, we keep
+// {mode, low, high} in flash and re-seed it in setup() before the first settings read.
+
+void CN105Climate::restore_setpoint_state_() {
+    if (!this->restore_setpoints_) {
+        return;
+    }
+    this->setpoint_pref_ = global_preferences->make_preference<SetpointState>(
+        this->get_object_id_hash() ^ 0x53504E54UL);  // XOR 'SPNT'
+    this->setpoint_pref_ready_ = true;
+
+    SetpointState s{};
+    if (!this->setpoint_pref_.load(&s)) {
+        ESP_LOGI("restore", "restore_setpoints: no saved HEAT_COOL band in flash");
+        return;
+    }
+    if (s.version != 1 || s.mode != static_cast<uint8_t>(climate::CLIMATE_MODE_HEAT_COOL) ||
+        std::isnan(s.target_low) || std::isnan(s.target_high)) {
+        ESP_LOGD("restore", "restore_setpoints: saved state is not a restorable HEAT_COOL band (mode=%u)", s.mode);
+        return;
+    }
+    if (!this->supports_dual_setpoint_) {
+        ESP_LOGW("restore", "restore_setpoints: saved HEAT_COOL band found but dual_setpoint not enabled; ignoring");
+        return;
+    }
+    // Seed HEAT_COOL + band before the first settings read. checkPowerAndModeSettings()
+    // keeps HEAT_COOL while the unit reports hardware-AUTO; if the user switched the unit to
+    // an explicit HEAT/COOL/OFF on the IR remote while powered off, that read path overrides
+    // this seed (remote wins), so no extra conflict handling is needed here.
+    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+    this->setTargetTemperatureLow(s.target_low);
+    this->setTargetTemperatureHigh(s.target_high);
+    ESP_LOGI("restore", "restore_setpoints: restored HEAT_COOL band low=%.1f high=%.1f", s.target_low, s.target_high);
+}
+
+void CN105Climate::save_setpoint_state_() {
+    if (!this->restore_setpoints_ || !this->setpoint_pref_ready_) {
+        return;
+    }
+    SetpointState s{};
+    s.version = 1;
+    s.mode = static_cast<uint8_t>(this->mode);
+    s.target_low = this->getTargetTemperatureLow();
+    s.target_high = this->getTargetTemperatureHigh();
+    if (this->setpoint_pref_.save(&s)) {
+        ESP_LOGD("restore", "restore_setpoints: saved mode=%u low=%.1f high=%.1f", s.mode, s.target_low, s.target_high);
     }
 }

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -29,6 +29,7 @@
 #include <esphome/components/sensor/sensor.h>
 #include <esphome/components/button/button.h>
 #include <esphome/components/binary_sensor/binary_sensor.h>
+#include "esphome/core/preferences.h"
 #include "cycle_management.h"
 #include <vector>
 #include <map>
@@ -282,6 +283,9 @@ namespace esphome {
         // UnitÃÂ© de puissance brute envoyÃÂ©e par la PAC: false = Watts (dÃÂ©faut), true = BTU/s
         void set_power_unit_is_btu(bool v) { this->power_unit_is_btu_ = v; }
 
+        // Opt-in (supports.restore_setpoints): persist HEAT_COOL band across reboots
+        void set_restore_setpoints(bool v) { this->restore_setpoints_ = v; }
+
         // Configure the climate object with traits that we support.
 
 
@@ -529,5 +533,21 @@ namespace esphome {
         bool supports_dual_setpoint_ = false;
         int horizontal_vanes_{ 1 }; // Kept for legacy logging if needed, or can be removed if unused.
         VaneType vane_type_{ VaneType::STANDARD };
+
+        // --- HEAT_COOL setpoint persistence (opt-in via supports.restore_setpoints) ---
+        // The dual-setpoint band is synthetic (the heat pump only stores a single setpoint),
+        // so it is lost on reboot. When enabled, we persist {mode, low, high} to flash and
+        // re-seed it in setup() before the first settings read.
+        struct SetpointState {
+            uint8_t version;
+            uint8_t mode;        // climate::ClimateMode
+            float target_low;
+            float target_high;
+        } __attribute__((packed));
+        bool restore_setpoints_ = false;
+        esphome::ESPPreferenceObject setpoint_pref_;
+        bool setpoint_pref_ready_ = false;
+        void restore_setpoint_state_();
+        void save_setpoint_state_();
     };
 }

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -45,6 +45,10 @@ void CN105Climate::setup() {
     this->supports_dual_setpoint_ = this->traits_.has_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
     ESP_LOGI(TAG, "Dual setpoint support configured: %s", this->supports_dual_setpoint_ ? "YES" : "NO");
     ESP_LOGI(TAG, "Horizontal vanes configured: %d", this->horizontal_vanes_);
+
+    // Restore a previously-saved HEAT_COOL band (opt-in) before the first settings read,
+    // so checkPowerAndModeSettings() keeps HEAT_COOL instead of falling back to AUTO.
+    this->restore_setpoint_state_();
 }
 
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(cn105_tests
     test_real_frames.cpp
     test_frame_parser.cpp
     test_protocol.cpp
+    test_setpoint_persistence.cpp
 )
 
 target_link_libraries(cn105_tests

--- a/tests/unit/test_setpoint_persistence.cpp
+++ b/tests/unit/test_setpoint_persistence.cpp
@@ -1,0 +1,127 @@
+/// test_setpoint_persistence.cpp — Regression tests for HEAT_COOL band
+/// persistence across reboots (opt-in `supports.restore_setpoints`).
+///
+/// Bug: the dual-setpoint band is synthetic — a Mitsubishi unit stores only a
+/// single setpoint and runs HEAT_COOL as hardware AUTO, so the user's low/high
+/// band lives only in RAM. On reboot, setup() NANs target_temperature_low/high
+/// (componentEntries.cpp) and the unit's hardware-AUTO report drives the entity
+/// back to CLIMATE_MODE_AUTO (hp_readings.cpp), losing both the HEAT_COOL mode
+/// and the band.
+///
+/// Fix (opt-in): persist {version, mode, low, high} to flash on every applied
+/// control, and in setup() re-seed HEAT_COOL + the band before the first
+/// settings read. The existing AUTO-branch guard in checkPowerAndModeSettings()
+/// then keeps HEAT_COOL; an explicit HEAT/COOL/OFF reported by the unit (user
+/// changed it on the IR remote while powered off) still overrides the seed
+/// (remote wins), so no extra conflict handling is needed.
+///
+/// Pattern: standalone reimplementation of the restore decision (same approach
+/// as test_mode_preservation.cpp / test_calculate_temp.cpp). The production code
+/// is a method on the full CN105Climate object using esphome preferences and
+/// climate::ClimateMode, which the gtest mocks do not provide, so a local mirror
+/// is used. The mirror is kept faithful to restore_setpoint_state_() /
+/// save_setpoint_state_() in components/cn105/climateControls.cpp.
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+// Local mirror of esphome::climate::ClimateMode (numeric values are irrelevant
+// to the decision; only "is it HEAT_COOL" matters, mirroring the production
+// `s.mode == static_cast<uint8_t>(climate::CLIMATE_MODE_HEAT_COOL)` check).
+enum class Mode : uint8_t { OFF, HEAT_COOL, COOL, HEAT, FAN_ONLY, DRY, AUTO };
+
+constexpr uint8_t kStateVersion = 1;
+
+// Mirror of CN105Climate::SetpointState (cn105.h).
+struct SetpointState {
+    uint8_t version;
+    uint8_t mode;
+    float target_low;
+    float target_high;
+};
+
+struct RestoreResult {
+    bool seed;        // did we re-seed HEAT_COOL + band?
+    Mode mode;
+    float low;
+    float high;
+};
+
+// Mirror of CN105Climate::save_setpoint_state_() (climateControls.cpp):
+// packs the current mode + band into the persisted struct.
+SetpointState saveState(Mode mode, float low, float high) {
+    return SetpointState{kStateVersion, static_cast<uint8_t>(mode), low, high};
+}
+
+// Mirror of CN105Climate::restore_setpoint_state_() (climateControls.cpp):
+// decides whether to re-seed HEAT_COOL + band on boot.
+RestoreResult restoreDecision(bool restoreEnabled, bool loaded,
+                              const SetpointState& s, bool supportsDual) {
+    RestoreResult r{false, Mode::OFF, NAN, NAN};
+    if (!restoreEnabled) return r;                                   // feature off
+    if (!loaded) return r;                                           // nothing in flash
+    if (s.version != kStateVersion) return r;                        // version mismatch
+    if (s.mode != static_cast<uint8_t>(Mode::HEAT_COOL)) return r;   // only HEAT_COOL is synthetic
+    if (std::isnan(s.target_low) || std::isnan(s.target_high)) return r;
+    if (!supportsDual) return r;                                     // dual_setpoint not enabled
+    return RestoreResult{true, Mode::HEAT_COOL, s.target_low, s.target_high};
+}
+
+}  // namespace
+
+// ── Happy path: a saved HEAT_COOL band is restored exactly ──
+
+TEST(SetpointPersistenceTest, RestoresHeatCoolBand) {
+    auto s = saveState(Mode::HEAT_COOL, 20.0f, 24.0f);
+    auto r = restoreDecision(/*restoreEnabled=*/true, /*loaded=*/true, s, /*dual=*/true);
+    EXPECT_TRUE(r.seed);
+    EXPECT_EQ(r.mode, Mode::HEAT_COOL);
+    EXPECT_FLOAT_EQ(r.low, 20.0f);
+    EXPECT_FLOAT_EQ(r.high, 24.0f);
+}
+
+TEST(SetpointPersistenceTest, SaveRestoreRoundTripIsLossless) {
+    auto s = saveState(Mode::HEAT_COOL, 18.5f, 23.5f);
+    auto r = restoreDecision(true, true, s, true);
+    ASSERT_TRUE(r.seed);
+    EXPECT_FLOAT_EQ(r.low, 18.5f);
+    EXPECT_FLOAT_EQ(r.high, 23.5f);
+}
+
+// ── Opt-in: nothing happens unless the feature is enabled ──
+
+TEST(SetpointPersistenceTest, DisabledDoesNotRestore) {
+    auto s = saveState(Mode::HEAT_COOL, 20.0f, 24.0f);
+    EXPECT_FALSE(restoreDecision(/*restoreEnabled=*/false, true, s, true).seed);
+}
+
+TEST(SetpointPersistenceTest, NoSavedStateDoesNotRestore) {
+    SetpointState empty{};  // load() failed
+    EXPECT_FALSE(restoreDecision(true, /*loaded=*/false, empty, true).seed);
+}
+
+// ── Guards: never restore a stale / non-HEAT_COOL / invalid record ──
+
+TEST(SetpointPersistenceTest, VersionMismatchDoesNotRestore) {
+    SetpointState s{kStateVersion + 1u, static_cast<uint8_t>(Mode::HEAT_COOL), 20.0f, 24.0f};
+    EXPECT_FALSE(restoreDecision(true, true, s, true).seed);
+}
+
+TEST(SetpointPersistenceTest, SingleModeDoesNotRestore) {
+    // Single modes (HEAT/COOL) are persisted by the heat pump itself, so we
+    // must not force HEAT_COOL when the last saved mode was single.
+    auto s = saveState(Mode::COOL, 22.0f, 22.0f);
+    EXPECT_FALSE(restoreDecision(true, true, s, true).seed);
+}
+
+TEST(SetpointPersistenceTest, NanBandDoesNotRestore) {
+    auto s = saveState(Mode::HEAT_COOL, NAN, 24.0f);
+    EXPECT_FALSE(restoreDecision(true, true, s, true).seed);
+}
+
+TEST(SetpointPersistenceTest, DualNotSupportedDoesNotRestore) {
+    auto s = saveState(Mode::HEAT_COOL, 20.0f, 24.0f);
+    EXPECT_FALSE(restoreDecision(true, true, s, /*dual=*/false).seed);
+}


### PR DESCRIPTION
## Summary

The dual-setpoint **HEAT_COOL band is lost on every reboot/OTA** — the entity returns as hardware **AUTO** with the low/high band collapsed to a single setpoint. This adds an opt-in `supports: { restore_setpoints: true }` that persists the band to flash and restores it on boot.

## Root cause

The dual-setpoint band is synthetic: a Mitsubishi unit stores only a *single* setpoint and runs HEAT_COOL as hardware **AUTO** (`controlMode()`), so the user's low/high band lives only in RAM:

- `setup()` (`componentEntries.cpp`) runs `target_temperature_low = NAN; target_temperature_high = NAN;` on every boot, and nothing is persisted.
- On reconnect the unit reports **AUTO**, and `checkPowerAndModeSettings()` keeps HEAT_COOL only *if* `this->mode` is already HEAT_COOL (`hp_readings.cpp`):
  ```cpp
  // If we were in HEAT_COOL via HA, stay in HEAT_COOL even if HP says AUTO
  if (this->mode != climate::CLIMATE_MODE_HEAT_COOL) {
      this->mode = climate::CLIMATE_MODE_AUTO;
  }
  ```
  At boot `this->mode` is the default (not HEAT_COOL), so it falls to `AUTO` and the band (NaN) is gone.

This is the **boot** counterpart to the runtime drop in #676 — neither #676 nor #675 covers reboot, since both only protect HEAT_COOL when `this->mode` is *already* HEAT_COOL.

## Fix (opt-in)

New option `supports: { dual_setpoint: true, restore_setpoints: true }` (default **false** → existing behavior unchanged):

1. **Save** `{version, mode, low, high}` to an `ESPPreferenceObject` after every applied control (`controlDelegate()`).
2. **Restore** in `setup()`: if a valid saved HEAT_COOL record exists, seed `this->mode = HEAT_COOL` + the band **before the first settings read**, so the existing AUTO-branch guard keeps it.

**Conflict handling is implicit** (no new code): if the user changed the unit to an explicit HEAT/COOL/OFF on the IR remote while the ESP was off, the unit reports that mode and the current HEAT/COOL branches override the seed — the remote wins. (If #676 lands, its HEAT/COOL guards would also fire here; the restore should then become tentative-until-AUTO-confirmed — happy to coordinate.)

## Tested

- **Unit test** `tests/unit/test_setpoint_persistence.cpp` — mirrors the restore decision (same standalone pattern as `test_mode_preservation.cpp`): happy path, opt-in gate, and version / single-mode / NaN / no-dual guards.
- **Real hardware** (7× MSZ-class units, `dual_setpoint: true`, Celsius-internal): set HEAT_COOL 68–75 °F → safe-restart → entity returns **HEAT_COOL 68–75 °F**, vs. green AUTO without the patch.

## Notes / caveats

- ESPHome flushes preferences on clean reboot/OTA (shutdown hook), so those restore exactly. A hard power-cut loses changes newer than the last periodic flush (~`flash_write_interval`, default 60 s).
- The saved band assumes correct band math; for `fahrenheit_compatibility` users this is most reliable combined with #675. Celsius / manual-conversion setups are unaffected.

+86 lines of component code + a unit test; no behavior change unless `restore_setpoints` is enabled.
