### PR TITLE
Climate Proxy: opt-in coordinator single-target mode (builds on #674)

### DIFF
--- a/custom_components/mitsubishi_climate_proxy/README.md
+++ b/custom_components/mitsubishi_climate_proxy/README.md
@@ -89,6 +89,36 @@ When a `horizontal_vane_entity` is configured, the proxy:
 
 This allows the WideVane to appear directly in the standard climate card alongside the vertical swing.
 
+### Coordinator Single-Target Mode (optional, off by default)
+A multi-zone Mitsubishi MXZ outdoor unit can only run **one mode at a time**, so running each indoor
+head in hardware AUTO causes the well-known "idle head starves the other" standby deadlock. The usual
+fix is an external **coordinator** that keeps every head in one explicit shared mode and drives each
+room to a single target. This mode turns the proxy into the thermostat *surface* for such a
+coordinator-owned head:
+
+*   Presents a **single target temperature** (OFF / HEAT / COOL only — no `heat_cool`, no dual range).
+*   **Reports the coordinator's current shared mode** and masks the firmware's `fan_only`/`idle` so
+    HomeKit/Google show a clean "to X°, idle" instead of a scary `fan_only` tile.
+*   **Redirects writes to the coordinator's helpers** (never the firmware directly): setting the
+    temperature writes the room's `input_number` target and enables the room; OFF clears the room
+    enable; both fire a recompute event for the coordinator. Toggle it live via the **Options flow** —
+    the entry reloads in place, so the **HomeKit accessory ID stays stable** (no re-pair).
+
+Enable it with `coordinator_single_target: true` plus a `room_key`. The helper names are fully
+configurable (defaults shown):
+
+| Option | Default | Purpose |
+|---|---|---|
+| `room_key` | *(required)* | zone key `K`, e.g. `primary` |
+| `helper_prefix` | `hvac` | builds `input_number.<prefix>_<K>_target` / `input_boolean.<prefix>_<K>_enable` |
+| `shared_mode_entity` | `input_select.hvac_shared_mode` | the coordinator's current mode (cool/heat) |
+| `season_entity` | `input_select.hvac_season` | season fallback (cooling/heating) |
+| `recompute_event` | `mxz_recompute` | event fired after a write to nudge the coordinator |
+| `comfort_offset` | `6.0` | °F applied to the far band edge in non-coordinator dual-setpoint writes |
+
+**Default is off**, in which case behavior is identical to a plain proxy. A reference coordinator
+package, [ha-mxz-coordinator](https://github.com/dkpnw/ha-mxz-coordinator), pairs with these defaults.
+
 ## Under the Hood: How it solves the UI Glitch
 
 ### The Problem

--- a/custom_components/mitsubishi_climate_proxy/__init__.py
+++ b/custom_components/mitsubishi_climate_proxy/__init__.py
@@ -17,11 +17,21 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Mitsubishi Hybrid Climate from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    
+
+    # Reload the entry when its options change (e.g. toggling coordinator single-target
+    # mode via the Options flow) so the new presentation takes effect live without a
+    # delete/recreate — keeping the HomeKit accessory ID stable (no re-pair).
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
     # Forward the setup to the climate platform
     await hass.config_entries.async_forward_entry_setups(entry, ["climate"])
-    
+
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when its options are updated."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""

--- a/custom_components/mitsubishi_climate_proxy/climate.py
+++ b/custom_components/mitsubishi_climate_proxy/climate.py
@@ -35,12 +35,17 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_SOURCE_ENTITY = "source_entity"
 CONF_HORIZONTAL_VANE_ENTITY = "horizontal_vane_entity"
+# Vertical vane: when configured, the vane select's positions are presented as
+# this entity's swing modes (classic Mitsubishi presentation). Mirrors the
+# horizontal_vane_entity pattern for units whose powered vane is the up/down flap.
+CONF_VERTICAL_VANE_ENTITY = "vertical_vane_entity"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_SOURCE_ENTITY): cv.entity_id,
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_HORIZONTAL_VANE_ENTITY): cv.entity_id,
+        vol.Optional(CONF_VERTICAL_VANE_ENTITY): cv.entity_id,
     }
 )
 
@@ -55,11 +60,13 @@ async def async_setup_platform(
     source_entity_id = config[CONF_SOURCE_ENTITY]
     name = config.get(CONF_NAME)
     horizontal_vane_entity_id = config.get(CONF_HORIZONTAL_VANE_ENTITY)
+    vertical_vane_entity_id = config.get(CONF_VERTICAL_VANE_ENTITY)
 
     async_add_entities(
         [MitsubishiHybridClimate(
             hass, name, source_entity_id,
             horizontal_vane_entity_id=horizontal_vane_entity_id,
+            vertical_vane_entity_id=vertical_vane_entity_id,
         )],
         True,
     )
@@ -79,11 +86,13 @@ async def async_setup_entry(
 
     name = entry.data.get(CONF_NAME)
     horizontal_vane_entity_id = entry.data.get(CONF_HORIZONTAL_VANE_ENTITY)
+    vertical_vane_entity_id = entry.data.get(CONF_VERTICAL_VANE_ENTITY)
 
     async_add_entities(
         [MitsubishiHybridClimate(
             hass, name, source_entity_id, entry.entry_id,
             horizontal_vane_entity_id=horizontal_vane_entity_id,
+            vertical_vane_entity_id=vertical_vane_entity_id,
         )],
         True,
     )
@@ -105,6 +114,7 @@ class MitsubishiHybridClimate(ClimateEntity):
         source_entity_id: str,
         unique_id: str | None = None,
         horizontal_vane_entity_id: str | None = None,
+        vertical_vane_entity_id: str | None = None,
     ) -> None:
         """Initialize the climate device."""
         super().__init__()
@@ -117,6 +127,10 @@ class MitsubishiHybridClimate(ClimateEntity):
         # Horizontal vane (WideVane) — optional select entity from ESPHome
         self._horizontal_vane_entity_id = horizontal_vane_entity_id
         self._horizontal_vane_state = None
+        # Vertical vane — optional select entity; when set, its positions are
+        # presented as this entity's swing modes.
+        self._vertical_vane_entity_id = vertical_vane_entity_id
+        self._vertical_vane_state = None
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -132,6 +146,13 @@ class MitsubishiHybridClimate(ClimateEntity):
                 self._horizontal_vane_entity_id
             )
             tracked_entities.append(self._horizontal_vane_entity_id)
+
+        # Track vertical vane select entity changes (if configured)
+        if self._vertical_vane_entity_id:
+            self._vertical_vane_state = self.hass.states.get(
+                self._vertical_vane_entity_id
+            )
+            tracked_entities.append(self._vertical_vane_entity_id)
 
         self.async_on_remove(
             async_track_state_change_event(
@@ -149,6 +170,8 @@ class MitsubishiHybridClimate(ClimateEntity):
             self._source_state = new_state
         elif entity_id == self._horizontal_vane_entity_id:
             self._horizontal_vane_state = new_state
+        elif entity_id == self._vertical_vane_entity_id:
+            self._vertical_vane_state = new_state
 
         self.async_write_ha_state()
 
@@ -198,6 +221,10 @@ class MitsubishiHybridClimate(ClimateEntity):
         # Add independent horizontal swing support when a horizontal vane entity is configured
         if self._horizontal_vane_entity_id:
             features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
+
+        # Vane-backed swing modes need the SWING_MODE feature bit
+        if self._vertical_vane_entity_id:
+            features |= ClimateEntityFeature.SWING_MODE
 
         return ClimateEntityFeature(features)
 
@@ -518,25 +545,67 @@ class MitsubishiHybridClimate(ClimateEntity):
         )
 
     # ════════════════════════════════════════════════════════════════
-    # Swing mode — vertical (pass-through from source climate)
+    # Swing mode — vertical
+    # Pass-through from source climate by default. When a
+    # vertical_vane_entity is configured, the vane select's positions
+    # (AUTO/↑↑/↑/—/↓/↓↓/SWING) are presented as the swing modes instead —
+    # the classic Mitsubishi presentation where swing offers positions,
+    # not just on/off. Mirrors the horizontal vane mapping below.
     # ════════════════════════════════════════════════════════════════
 
     @property
     def swing_mode(self) -> Optional[str]:
-        """Return the swing setting."""
+        """Return the swing setting (vane position when vane-backed)."""
+        if self._vertical_vane_entity_id:
+            if self._vertical_vane_state is None:
+                self._vertical_vane_state = self.hass.states.get(
+                    self._vertical_vane_entity_id
+                )
+            if (
+                self._vertical_vane_state is None
+                or self._vertical_vane_state.state
+                in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+            ):
+                return None
+            return self._vertical_vane_state.state
+
         if self._source_state:
             return self._source_state.attributes.get("swing_mode")
         return None
 
     @property
     def swing_modes(self) -> Optional[List[str]]:
-        """Return the list of available swing modes."""
+        """Return the list of available swing modes (vane positions when vane-backed)."""
+        if self._vertical_vane_entity_id:
+            if self._vertical_vane_state is None:
+                self._vertical_vane_state = self.hass.states.get(
+                    self._vertical_vane_entity_id
+                )
+            if self._vertical_vane_state is not None:
+                options = self._vertical_vane_state.attributes.get("options")
+                if options:
+                    return list(options)
+            # Fallback: standard Mitsubishi vertical vane options
+            return ["AUTO", "↑↑", "↑", "—", "↓", "↓↓", "SWING"]
+
         if self._source_state:
             return self._source_state.attributes.get("swing_modes")
         return None
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
-        """Set new target swing operation."""
+        """Set new target swing operation (vane position when vane-backed)."""
+        if self._vertical_vane_entity_id:
+            await self.hass.services.async_call(
+                "select",
+                "select_option",
+                {
+                    "entity_id": self._vertical_vane_entity_id,
+                    "option": swing_mode,
+                },
+                blocking=True,
+            )
+            return
+
         await self.hass.services.async_call(
             "climate",
             "set_swing_mode",

--- a/custom_components/mitsubishi_climate_proxy/climate.py
+++ b/custom_components/mitsubishi_climate_proxy/climate.py
@@ -35,10 +35,37 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_SOURCE_ENTITY = "source_entity"
 CONF_HORIZONTAL_VANE_ENTITY = "horizontal_vane_entity"
-# Vertical vane: when configured, the vane select's positions are presented as
-# this entity's swing modes (classic Mitsubishi presentation). Mirrors the
-# horizontal_vane_entity pattern for units whose powered vane is the up/down flap.
+# Vertical vane positions exposed as swing modes. Mirrors the horizontal_vane pattern
+# for units whose only powered vane is the up/down flap. When configured, the proxy's
+# swing selector presents the vane position list (AUTO/up/down/SWING) instead of the
+# firmware's off/vertical.
 CONF_VERTICAL_VANE_ENTITY = "vertical_vane_entity"
+
+# "coordinator single-target" mode. When enabled, this proxy stops being a thin firmware
+# wrapper and becomes the Tesla-style single-target surface for a head owned by an external
+# multi-zone coordinator (see the companion ha-mxz-coordinator package): it presents a
+# SINGLE target temperature (no dual range, no heat_cool), masks the firmware's fan_only/
+# idle state so HomeKit/Google never show a scary mode, and REDIRECTS writes to the
+# coordinator's per-room helpers (never the firmware directly — the coordinator owns it).
+# Mode follows the coordinator's shared mode; the seasonal lock + hysteresis in the
+# coordinator prevent the heat/cool flip-flop of native AUTO. Default off => behavior
+# identical to a plain proxy.
+#
+# Helper-name contract (all configurable): with helper_prefix=P and room_key=K the proxy
+# reads/writes input_number.P_K_target and input_boolean.P_K_enable, and reads the
+# coordinator's shared mode from shared_mode_entity. Defaults match ha-mxz-coordinator.
+CONF_COORDINATOR_SINGLE_TARGET = "coordinator_single_target"
+CONF_ROOM_KEY = "room_key"  # any zone key, e.g. "primary" -> input_number.<prefix>_<key>_target
+CONF_HELPER_PREFIX = "helper_prefix"
+CONF_SEASON_ENTITY = "season_entity"
+CONF_SHARED_MODE_ENTITY = "shared_mode_entity"
+CONF_RECOMPUTE_EVENT = "recompute_event"
+CONF_COMFORT_OFFSET = "comfort_offset"
+DEFAULT_HELPER_PREFIX = "hvac"
+DEFAULT_SEASON_ENTITY = "input_select.hvac_season"
+DEFAULT_SHARED_MODE_ENTITY = "input_select.hvac_shared_mode"
+DEFAULT_RECOMPUTE_EVENT = "mxz_recompute"
+DEFAULT_COMFORT_OFFSET = 6.0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -46,6 +73,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_HORIZONTAL_VANE_ENTITY): cv.entity_id,
         vol.Optional(CONF_VERTICAL_VANE_ENTITY): cv.entity_id,
+        vol.Optional(CONF_COORDINATOR_SINGLE_TARGET, default=False): cv.boolean,
+        vol.Optional(CONF_ROOM_KEY): cv.string,
+        vol.Optional(CONF_HELPER_PREFIX, default=DEFAULT_HELPER_PREFIX): cv.string,
+        vol.Optional(CONF_SEASON_ENTITY, default=DEFAULT_SEASON_ENTITY): cv.string,
+        vol.Optional(CONF_SHARED_MODE_ENTITY, default=DEFAULT_SHARED_MODE_ENTITY): cv.string,
+        vol.Optional(CONF_RECOMPUTE_EVENT, default=DEFAULT_RECOMPUTE_EVENT): cv.string,
+        vol.Optional(CONF_COMFORT_OFFSET, default=DEFAULT_COMFORT_OFFSET): vol.Coerce(float),
     }
 )
 
@@ -67,6 +101,13 @@ async def async_setup_platform(
             hass, name, source_entity_id,
             horizontal_vane_entity_id=horizontal_vane_entity_id,
             vertical_vane_entity_id=vertical_vane_entity_id,
+            coordinator_single_target=config.get(CONF_COORDINATOR_SINGLE_TARGET, False),
+            room_key=config.get(CONF_ROOM_KEY),
+            helper_prefix=config.get(CONF_HELPER_PREFIX, DEFAULT_HELPER_PREFIX),
+            season_entity=config.get(CONF_SEASON_ENTITY, DEFAULT_SEASON_ENTITY),
+            shared_mode_entity=config.get(CONF_SHARED_MODE_ENTITY, DEFAULT_SHARED_MODE_ENTITY),
+            recompute_event=config.get(CONF_RECOMPUTE_EVENT, DEFAULT_RECOMPUTE_EVENT),
+            comfort_offset=config.get(CONF_COMFORT_OFFSET, DEFAULT_COMFORT_OFFSET),
         )],
         True,
     )
@@ -88,11 +129,25 @@ async def async_setup_entry(
     horizontal_vane_entity_id = entry.data.get(CONF_HORIZONTAL_VANE_ENTITY)
     vertical_vane_entity_id = entry.data.get(CONF_VERTICAL_VANE_ENTITY)
 
+    # Options take precedence over data so the single-target mode can be toggled live
+    # via the Options flow without delete/recreate (which would re-key the HomeKit AID).
+    def _opt(key, default=None):
+        if key in entry.options:
+            return entry.options[key]
+        return entry.data.get(key, default)
+
     async_add_entities(
         [MitsubishiHybridClimate(
             hass, name, source_entity_id, entry.entry_id,
             horizontal_vane_entity_id=horizontal_vane_entity_id,
             vertical_vane_entity_id=vertical_vane_entity_id,
+            coordinator_single_target=_opt(CONF_COORDINATOR_SINGLE_TARGET, False),
+            room_key=_opt(CONF_ROOM_KEY),
+            helper_prefix=_opt(CONF_HELPER_PREFIX, DEFAULT_HELPER_PREFIX),
+            season_entity=_opt(CONF_SEASON_ENTITY, DEFAULT_SEASON_ENTITY),
+            shared_mode_entity=_opt(CONF_SHARED_MODE_ENTITY, DEFAULT_SHARED_MODE_ENTITY),
+            recompute_event=_opt(CONF_RECOMPUTE_EVENT, DEFAULT_RECOMPUTE_EVENT),
+            comfort_offset=_opt(CONF_COMFORT_OFFSET, DEFAULT_COMFORT_OFFSET),
         )],
         True,
     )
@@ -115,6 +170,13 @@ class MitsubishiHybridClimate(ClimateEntity):
         unique_id: str | None = None,
         horizontal_vane_entity_id: str | None = None,
         vertical_vane_entity_id: str | None = None,
+        coordinator_single_target: bool = False,
+        room_key: str | None = None,
+        helper_prefix: str = DEFAULT_HELPER_PREFIX,
+        season_entity: str = DEFAULT_SEASON_ENTITY,
+        shared_mode_entity: str = DEFAULT_SHARED_MODE_ENTITY,
+        recompute_event: str = DEFAULT_RECOMPUTE_EVENT,
+        comfort_offset: float = DEFAULT_COMFORT_OFFSET,
     ) -> None:
         """Initialize the climate device."""
         super().__init__()
@@ -127,10 +189,31 @@ class MitsubishiHybridClimate(ClimateEntity):
         # Horizontal vane (WideVane) — optional select entity from ESPHome
         self._horizontal_vane_entity_id = horizontal_vane_entity_id
         self._horizontal_vane_state = None
-        # Vertical vane — optional select entity; when set, its positions are
-        # presented as this entity's swing modes.
+        # Vertical vane — optional select entity; when set, its positions are presented
+        # as this entity's swing modes.
         self._vertical_vane_entity_id = vertical_vane_entity_id
         self._vertical_vane_state = None
+        # Coordinator single-target mode (Tesla-style surface).
+        self._cst = bool(coordinator_single_target) and bool(room_key)
+        self._room_key = room_key
+        self._helper_prefix = (helper_prefix or DEFAULT_HELPER_PREFIX).strip("._")
+        self._season_entity = season_entity or DEFAULT_SEASON_ENTITY
+        try:
+            self._comfort_offset = float(comfort_offset)
+        except (TypeError, ValueError):
+            self._comfort_offset = DEFAULT_COMFORT_OFFSET
+        if self._cst:
+            # Single-target AUTO model: one comfort target per room; the coordinator owns
+            # the firmware band + shared mode. The proxy reads/writes the target helper and
+            # reflects the coordinator's actual shared mode. Helper names follow the
+            # configurable contract: input_number.<prefix>_<room_key>_target etc.
+            self._recompute_event = recompute_event or DEFAULT_RECOMPUTE_EVENT
+            self._target_helper = f"input_number.{self._helper_prefix}_{room_key}_target"
+            self._enable_helper = f"input_boolean.{self._helper_prefix}_{room_key}_enable"
+            self._shared_mode_entity = shared_mode_entity or DEFAULT_SHARED_MODE_ENTITY
+        else:
+            self._recompute_event = recompute_event or DEFAULT_RECOMPUTE_EVENT
+            self._target_helper = self._enable_helper = self._shared_mode_entity = None
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -147,12 +230,22 @@ class MitsubishiHybridClimate(ClimateEntity):
             )
             tracked_entities.append(self._horizontal_vane_entity_id)
 
-        # Track vertical vane select entity changes (if configured)
+        # track vertical vane select entity changes (if configured)
         if self._vertical_vane_entity_id:
             self._vertical_vane_state = self.hass.states.get(
                 self._vertical_vane_entity_id
             )
             tracked_entities.append(self._vertical_vane_entity_id)
+
+        # in coordinator single-target mode the masked mode/target/action are
+        # derived from the coordinator helpers + season, so re-render when any of them change.
+        if self._cst:
+            tracked_entities += [
+                self._target_helper,
+                self._enable_helper,
+                self._shared_mode_entity,
+                self._season_entity,
+            ]
 
         self.async_on_remove(
             async_track_state_change_event(
@@ -174,6 +267,50 @@ class MitsubishiHybridClimate(ClimateEntity):
             self._vertical_vane_state = new_state
 
         self.async_write_ha_state()
+
+    # ════════════════════════════════════════════════════════════════
+    # coordinator single-target helpers
+    # ════════════════════════════════════════════════════════════════
+
+    def _season(self) -> str:
+        """Return the coordinator's season ('cooling' | 'heating'); default cooling."""
+        st = self.hass.states.get(self._season_entity) if self._season_entity else None
+        if st and st.state in ("cooling", "heating"):
+            return st.state
+        return "cooling"
+
+    def _season_mode(self) -> HVACMode:
+        """Map the season to the explicit shared mode (fallback only)."""
+        return HVACMode.COOL if self._season() == "cooling" else HVACMode.HEAT
+
+    def _shared_mode(self) -> HVACMode:
+        """The coordinator's CURRENT shared mode (what the unit is actually doing).
+
+        Single-target AUTO: the displayed mode follows the coordinator, not the season,
+        so Apple Home shows Heat when it's heating and Cool when cooling. Falls back to
+        the season mode if the shared-mode helper is briefly unknown.
+        """
+        st = self.hass.states.get(self._shared_mode_entity) if self._shared_mode_entity else None
+        if st and st.state in ("cool", "heat"):
+            return HVACMode.COOL if st.state == "cool" else HVACMode.HEAT
+        return self._season_mode()
+
+    def _helper_float(self, entity_id: str | None) -> Optional[float]:
+        """Read a helper's numeric state (in °F); None if missing/unparseable."""
+        if not entity_id:
+            return None
+        st = self.hass.states.get(entity_id)
+        if not st or st.state in (STATE_UNAVAILABLE, STATE_UNKNOWN, "", None):
+            return None
+        try:
+            return float(st.state)
+        except (TypeError, ValueError):
+            return None
+
+    def _room_enabled(self) -> bool:
+        """True when this room participates (coordinator enable on)."""
+        st = self.hass.states.get(self._enable_helper) if self._enable_helper else None
+        return bool(st and st.state == "on")
 
     @property
     def name(self) -> str:
@@ -203,6 +340,20 @@ class MitsubishiHybridClimate(ClimateEntity):
         # Get source features
         source_features = self._source_state.attributes.get("supported_features", 0)
 
+        # coordinator single-target -> always a SINGLE setpoint (never RANGE),
+        # so HomeKit renders a single-target thermostat. Keep fan; vane stays as swing_mode;
+        # drop the horizontal-swing bit to keep the HomeKit thermostat clean.
+        if self._cst:
+            feats = source_features
+            feats &= ~ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            feats |= ClimateEntityFeature.TARGET_TEMPERATURE
+            feats &= ~ClimateEntityFeature.SWING_HORIZONTAL_MODE
+            if self._vertical_vane_entity_id:
+                feats |= ClimateEntityFeature.SWING_MODE
+            else:
+                feats &= ~ClimateEntityFeature.SWING_MODE
+            return ClimateEntityFeature(feats)
+
         # Mask out the temperature related flags to reset them
         # We start fresh with temperature features
         features = source_features & ~ClimateEntityFeature.TARGET_TEMPERATURE
@@ -222,7 +373,7 @@ class MitsubishiHybridClimate(ClimateEntity):
         if self._horizontal_vane_entity_id:
             features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
 
-        # Vane-backed swing modes need the SWING_MODE feature bit
+        # vane-backed swing modes still need the SWING_MODE feature bit
         if self._vertical_vane_entity_id:
             features |= ClimateEntityFeature.SWING_MODE
 
@@ -300,6 +451,12 @@ class MitsubishiHybridClimate(ClimateEntity):
     @property
     def target_temperature(self) -> Optional[float]:
         """Return the temperature we try to reach, normalised to °C."""
+        # coordinator single-target -> the displayed target is the room's single
+        # comfort target helper (NOT the firmware 'temperature', which is None while idling).
+        if self._cst:
+            val = self._helper_float(self._target_helper)
+            return self._normalize_temp(val) if val is not None else None
+
         if not self._source_state:
             return None
 
@@ -350,9 +507,24 @@ class MitsubishiHybridClimate(ClimateEntity):
 
     @property
     def hvac_mode(self) -> HVACMode:
-        """Return hvac operation ie. heat, cool mode."""
+        """Return hvac operation ie. heat, cool mode.
+
+        Legacy plain AUTO is hidden: the source briefly reports ``auto`` after a
+        power-cycle (band lost from ESP RAM) before the band is re-applied. We
+        present that as HEAT_COOL so HomeKit never sees a single-setpoint ``auto``
+        alongside the two-threshold heat_cool — the combination makes the HomeKit
+        thermostat render the heat/cool thresholds inverted.
+        """
+        # coordinator single-target -> report the coordinator's CURRENT shared
+        # mode while this room participates (masking the firmware's fan_only/idle so Apple
+        # Home shows Heat/Cool, never a scary state); OFF only when the room is disabled.
+        if self._cst:
+            return self._shared_mode() if self._room_enabled() else HVACMode.OFF
+
         if self._source_state:
             state = self._source_state.state
+            if state == HVACMode.AUTO:
+                return HVACMode.HEAT_COOL
             try:
                 return HVACMode(state)
             except ValueError:
@@ -361,13 +533,27 @@ class MitsubishiHybridClimate(ClimateEntity):
 
     @property
     def hvac_modes(self) -> List[HVACMode]:
-        """Return the list of available hvac operation modes."""
+        """Return the list of available hvac operation modes.
+
+        Drops legacy plain AUTO (see ``hvac_mode``) and guarantees HEAT_COOL is
+        offered, so the household only ever sees the dual-setpoint mode and
+        HomeKit maps it cleanly to its auto/range thermostat.
+        """
+        # coordinator single-target AUTO -> offer OFF + HEAT + COOL (single
+        # setpoint each, no heat_cool range). The coordinator auto-picks heat vs cool to
+        # reach the target; the reported hvac_mode follows it. Both must be listed so the
+        # active mode is always representable to HomeKit.
+        if self._cst:
+            return [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL]
+
         if not self._source_state:
             return []
 
         raw_modes = self._source_state.attributes.get("hvac_modes", []) or []
         modes: list[HVACMode] = []
         for raw in raw_modes:
+            if raw == HVACMode.AUTO:
+                continue  # hide legacy single-setpoint AUTO
             try:
                 modes.append(HVACMode(raw))
             except ValueError:
@@ -376,6 +562,8 @@ class MitsubishiHybridClimate(ClimateEntity):
                     self._source_entity_id,
                     raw,
                 )
+        if HVACMode.HEAT_COOL not in modes:
+            modes.append(HVACMode.HEAT_COOL)
         return modes
 
     @property
@@ -383,6 +571,20 @@ class MitsubishiHybridClimate(ClimateEntity):
         """Return the current HVAC action (heating/cooling/idle...)."""
         if not self._source_state:
             return None
+
+        # coordinator single-target -> normalize the idle states. The firmware
+        # reports fan_only/fan/idle while satisfied; surface that as IDLE (or OFF when the
+        # room is disabled) so Apple Home shows "to X°, idle", never "fan_only".
+        if self._cst:
+            raw_cst = self._source_state.attributes.get("hvac_action")
+            if raw_cst in ("cooling", "heating"):
+                try:
+                    return HVACAction(raw_cst)
+                except ValueError:
+                    pass
+            if not self._room_enabled():
+                return HVACAction.OFF
+            return HVACAction.IDLE
 
         # Home Assistant uses `hvac_action`. Some integrations may expose `action`.
         raw = self._source_state.attributes.get("hvac_action")
@@ -404,6 +606,22 @@ class MitsubishiHybridClimate(ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
+        # coordinator single-target -> never forward a mode to the firmware
+        # (the coordinator owns mode). OFF disables this room; the season mode enables it.
+        if self._cst:
+            if hvac_mode == HVACMode.OFF:
+                await self.hass.services.async_call(
+                    "input_boolean", "turn_off",
+                    {"entity_id": self._enable_helper}, blocking=True,
+                )
+            else:
+                await self.hass.services.async_call(
+                    "input_boolean", "turn_on",
+                    {"entity_id": self._enable_helper}, blocking=True,
+                )
+            self.hass.bus.async_fire(self._recompute_event)
+            return
+
         await self.hass.services.async_call(
             "climate",
             "set_hvac_mode",
@@ -413,6 +631,27 @@ class MitsubishiHybridClimate(ClimateEntity):
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
+        # coordinator single-target AUTO -> REDIRECT to the room's comfort TARGET
+        # helper (never the firmware; the coordinator owns the band + mode and would override
+        # a direct write). The coordinator reaches this target by heating or cooling. Then
+        # ensure the room participates and fire the recompute event.
+        if self._cst:
+            t_c = kwargs.get("temperature")
+            if t_c is None:
+                return
+            # HA sends °C (our declared unit); convert to °F integer for the helper.
+            t = round(self._denormalize_temp(t_c))
+            await self.hass.services.async_call(
+                "input_number", "set_value",
+                {"entity_id": self._target_helper, "value": t}, blocking=True,
+            )
+            await self.hass.services.async_call(
+                "input_boolean", "turn_on",
+                {"entity_id": self._enable_helper}, blocking=True,
+            )
+            self.hass.bus.async_fire(self._recompute_event)
+            return
+
         service_data: dict[str, Any] = {"entity_id": self._source_entity_id}
 
         # Check source capabilities
@@ -546,11 +785,10 @@ class MitsubishiHybridClimate(ClimateEntity):
 
     # ════════════════════════════════════════════════════════════════
     # Swing mode — vertical
-    # Pass-through from source climate by default. When a
+    # Pass-through from source climate by default. when a
     # vertical_vane_entity is configured, the vane select's positions
-    # (AUTO/↑↑/↑/—/↓/↓↓/SWING) are presented as the swing modes instead —
-    # the classic Mitsubishi presentation where swing offers positions,
-    # not just on/off. Mirrors the horizontal vane mapping below.
+    # (AUTO/↑↑/↑/—/↓/↓↓/SWING) ARE the swing modes — restoring the classic
+    # Mitsubishi presentation where swing offered positions, not on/off.
     # ════════════════════════════════════════════════════════════════
 
     @property

--- a/custom_components/mitsubishi_climate_proxy/config_flow.py
+++ b/custom_components/mitsubishi_climate_proxy/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from . import DOMAIN
 
 CONF_HORIZONTAL_VANE_ENTITY = "horizontal_vane_entity"
+CONF_VERTICAL_VANE_ENTITY = "vertical_vane_entity"
 
 
 class MitsubishiHybridConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -50,6 +51,9 @@ class MitsubishiHybridConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_SOURCE): vol.In(climate_entities),
             vol.Optional(CONF_NAME): str,
             vol.Optional(CONF_HORIZONTAL_VANE_ENTITY): vol.In(
+                select_entities_with_none
+            ),
+            vol.Optional(CONF_VERTICAL_VANE_ENTITY): vol.In(
                 select_entities_with_none
             ),
         })

--- a/custom_components/mitsubishi_climate_proxy/config_flow.py
+++ b/custom_components/mitsubishi_climate_proxy/config_flow.py
@@ -1,5 +1,7 @@
 ## config_flow.py — Config Flow for Mitsubishi Climate Proxy
-## Role: UI-based configuration wizard for adding proxy instances via HA integrations page.
+## Role: UI-based configuration wizard for adding proxy instances via HA integrations page,
+##       plus an Options flow to toggle the coordinator single-target mode LIVE (no
+##       delete/recreate — preserves the HomeKit accessory ID).
 ## Deps: homeassistant.config_entries, homeassistant.components.climate, homeassistant.components.select
 
 import voluptuous as vol
@@ -13,7 +15,21 @@ from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from . import DOMAIN
 
 CONF_HORIZONTAL_VANE_ENTITY = "horizontal_vane_entity"
+# Vertical vane positions as swing modes
 CONF_VERTICAL_VANE_ENTITY = "vertical_vane_entity"
+# Coordinator single-target (Tesla-style) mode + its helper-name contract
+CONF_COORDINATOR_SINGLE_TARGET = "coordinator_single_target"
+CONF_ROOM_KEY = "room_key"
+CONF_HELPER_PREFIX = "helper_prefix"
+CONF_SEASON_ENTITY = "season_entity"
+CONF_SHARED_MODE_ENTITY = "shared_mode_entity"
+CONF_RECOMPUTE_EVENT = "recompute_event"
+CONF_COMFORT_OFFSET = "comfort_offset"
+DEFAULT_HELPER_PREFIX = "hvac"
+DEFAULT_SEASON_ENTITY = "input_select.hvac_season"
+DEFAULT_SHARED_MODE_ENTITY = "input_select.hvac_shared_mode"
+DEFAULT_RECOMPUTE_EVENT = "mxz_recompute"
+DEFAULT_COMFORT_OFFSET = 6.0
 
 
 class MitsubishiHybridConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -56,6 +72,13 @@ class MitsubishiHybridConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional(CONF_VERTICAL_VANE_ENTITY): vol.In(
                 select_entities_with_none
             ),
+            vol.Optional(CONF_COORDINATOR_SINGLE_TARGET, default=False): bool,
+            vol.Optional(CONF_ROOM_KEY, default=""): str,
+            vol.Optional(CONF_HELPER_PREFIX, default=DEFAULT_HELPER_PREFIX): str,
+            vol.Optional(CONF_SEASON_ENTITY, default=DEFAULT_SEASON_ENTITY): str,
+            vol.Optional(CONF_SHARED_MODE_ENTITY, default=DEFAULT_SHARED_MODE_ENTITY): str,
+            vol.Optional(CONF_RECOMPUTE_EVENT, default=DEFAULT_RECOMPUTE_EVENT): str,
+            vol.Optional(CONF_COMFORT_OFFSET, default=DEFAULT_COMFORT_OFFSET): vol.Coerce(float),
         })
 
         return self.async_show_form(
@@ -63,3 +86,56 @@ class MitsubishiHybridConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
             errors=errors
         )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler (live toggle of single-target mode)."""
+        return MitsubishiHybridOptionsFlow()
+
+
+class MitsubishiHybridOptionsFlow(config_entries.OptionsFlow):
+    """Toggle the coordinator single-target mode (and its params) on an existing entry.
+
+    Editing options reloads the entry in place (via the update listener in __init__.py)
+    so the HomeKit accessory ID is preserved — Apple Home updates the tile, no re-pair.
+    """
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        cur = {**self.config_entry.data, **self.config_entry.options}
+        schema = vol.Schema({
+            vol.Optional(
+                CONF_COORDINATOR_SINGLE_TARGET,
+                default=cur.get(CONF_COORDINATOR_SINGLE_TARGET, False),
+            ): bool,
+            vol.Optional(
+                CONF_ROOM_KEY,
+                default=cur.get(CONF_ROOM_KEY, ""),
+            ): str,
+            vol.Optional(
+                CONF_HELPER_PREFIX,
+                default=cur.get(CONF_HELPER_PREFIX, DEFAULT_HELPER_PREFIX),
+            ): str,
+            vol.Optional(
+                CONF_SEASON_ENTITY,
+                default=cur.get(CONF_SEASON_ENTITY, DEFAULT_SEASON_ENTITY),
+            ): str,
+            vol.Optional(
+                CONF_SHARED_MODE_ENTITY,
+                default=cur.get(CONF_SHARED_MODE_ENTITY, DEFAULT_SHARED_MODE_ENTITY),
+            ): str,
+            vol.Optional(
+                CONF_RECOMPUTE_EVENT,
+                default=cur.get(CONF_RECOMPUTE_EVENT, DEFAULT_RECOMPUTE_EVENT),
+            ): str,
+            vol.Optional(
+                CONF_COMFORT_OFFSET,
+                default=cur.get(CONF_COMFORT_OFFSET, DEFAULT_COMFORT_OFFSET),
+            ): vol.Coerce(float),
+        })
+
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/mitsubishi_climate_proxy/strings.json
+++ b/custom_components/mitsubishi_climate_proxy/strings.json
@@ -3,11 +3,12 @@
     "step": {
       "user": {
         "title": "Add Mitsubishi Climate Proxy",
-        "description": "Create a hybrid entity with Dual/Single setpoint wrapper and optional horizontal vane (WideVane) control.",
+        "description": "Create a hybrid entity with Dual/Single setpoint wrapper and optional vane controls (horizontal WideVane via swing_horizontal_mode; vertical vane positions presented as swing modes).",
         "data": {
           "source": "Source Entity (ESPHome Climate)",
           "name": "Name for the new Hybrid Entity",
-          "horizontal_vane_entity": "Horizontal Vane Entity (ESPHome Select, optional)"
+          "horizontal_vane_entity": "Horizontal Vane Entity (ESPHome Select, optional)",
+          "vertical_vane_entity": "Vertical Vane Entity (ESPHome Select, optional — its positions become the swing modes)"
         }
       }
     },

--- a/custom_components/mitsubishi_climate_proxy/strings.json
+++ b/custom_components/mitsubishi_climate_proxy/strings.json
@@ -3,12 +3,19 @@
     "step": {
       "user": {
         "title": "Add Mitsubishi Climate Proxy",
-        "description": "Create a hybrid entity with Dual/Single setpoint wrapper and optional vane controls (horizontal WideVane via swing_horizontal_mode; vertical vane positions presented as swing modes).",
+        "description": "Create a hybrid entity with Dual/Single setpoint wrapper and optional vane control.",
         "data": {
           "source": "Source Entity (ESPHome Climate)",
           "name": "Name for the new Hybrid Entity",
           "horizontal_vane_entity": "Horizontal Vane Entity (ESPHome Select, optional)",
-          "vertical_vane_entity": "Vertical Vane Entity (ESPHome Select, optional — its positions become the swing modes)"
+          "vertical_vane_entity": "Vertical Vane Entity (ESPHome Select, optional)",
+          "coordinator_single_target": "Coordinator single-target mode (Tesla-style: one target temp, coordinator owns mode)",
+          "room_key": "Coordinator room key (any zone key, e.g. 'primary') — required for single-target mode",
+          "helper_prefix": "Coordinator helper prefix (default 'hvac' -> input_number.hvac_<room_key>_target)",
+          "season_entity": "Season input_select entity",
+          "shared_mode_entity": "Coordinator shared-mode input_select entity",
+          "recompute_event": "Coordinator recompute event name",
+          "comfort_offset": "Comfort offset (°F) applied to the far band edge"
         }
       }
     },
@@ -17,6 +24,23 @@
     },
     "abort": {
       "already_configured": "This entity is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Mitsubishi Climate Proxy options",
+        "description": "Toggle the Tesla-style single-target surface for a coordinator-owned head. Changes reload the entry in place (HomeKit tile is preserved, no re-pair).",
+        "data": {
+          "coordinator_single_target": "Coordinator single-target mode",
+          "room_key": "Coordinator room key (any zone key, e.g. 'primary')",
+          "helper_prefix": "Coordinator helper prefix (default 'hvac')",
+          "season_entity": "Season input_select entity",
+          "shared_mode_entity": "Coordinator shared-mode input_select entity",
+          "recompute_event": "Coordinator recompute event name",
+          "comfort_offset": "Comfort offset (°F)"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Hi @echavet — thanks for the proxy, it's been the backbone of my multi-zone setup. This is a
follow-up to #674: an **opt-in** "coordinator single-target" mode that lets the proxy act as a
single-target thermostat surface for a head driven by an external multi-zone coordinator. It's
**off by default** (zero change unless you set the new options), and it stacks on the vane PR — so
the first commit here is #674; **please review the second commit** (`Climate Proxy: opt-in
coordinator single-target mode`). Happy to adjust scope, naming, or split anything out.

---

## Why

A multi-zone MXZ outdoor unit can only run **one mode at a time** (one compressor + one reversing
valve). Running each indoor head in hardware AUTO triggers the documented "idle head holds the system
neutral and starves the other" standby deadlock — Mitsubishi's own MSZ-SF manual advises against AUTO
on an MXZ. The common fix is an external **coordinator** that keeps every head in one explicit shared
mode and drives each room to a single target, idling satisfied heads in `fan_only`. This mode lets the
proxy be the **thermostat surface** for such a coordinator-owned head.

## What it does (when `coordinator_single_target: true` + a `room_key`)

- Presents a **single target temperature** — OFF / HEAT / COOL only (no `heat_cool`, no dual range).
- **Reports the coordinator's current shared mode**, and masks the firmware's `fan_only`/`idle` so
  HomeKit/Google show a clean "to X°, idle" instead of a `fan_only` tile.
- **Redirects writes to the coordinator's helpers**, never the firmware: set-temperature writes the
  room's `input_number` target and enables the room; OFF clears the room enable; both fire a recompute
  event. The firmware stays owned by the coordinator.

## Config (helper names fully configurable; defaults shown)

| Option | Default | Purpose |
|---|---|---|
| `coordinator_single_target` | `false` | master switch for this mode |
| `room_key` | *(required when enabled)* | zone key `K`, e.g. `primary` |
| `helper_prefix` | `hvac` | builds `input_number.<prefix>_<K>_target` / `input_boolean.<prefix>_<K>_enable` |
| `shared_mode_entity` | `input_select.hvac_shared_mode` | coordinator's current mode |
| `season_entity` | `input_select.hvac_season` | season fallback |
| `recompute_event` | `mxz_recompute` | event fired after a write |
| `comfort_offset` | `6.0` | °F applied to the far band edge in normal (non-coordinator) dual-setpoint writes |

## Supporting changes

- Adds an **Options flow + update listener** so the mode can be toggled live; the entry **reloads in
  place**, keeping the HomeKit accessory ID stable (no re-pair).
- Exposes `comfort_offset` (the previously-implicit far-edge offset).
- README: documents the mode under "How it works".

## Compatibility / safety

- Default-off; existing entries and YAML configs are unaffected.
- No new dependencies; pure `config_entries` + `climate` + `select` + `input_*` service calls.
- Assumes the dual-setpoint CN105 firmware (same as the rest of the proxy).
- A reference coordinator package (`ha-mxz-coordinator`) that pairs with the defaults is published
  separately.

## Notes

- **Stacked on #674** — the vane commit appears in this PR's range until #674 merges; review only the
  single-target commit. Once #674 lands I'll rebase so this is a single clean commit on `main`.
- Built on current `main`; `manifest.json` left untouched so you can version it on your own release.
