### PR TITLE
docs(proxy): highlight ha-mxz-coordinator as a one-click HACS integration

### DIFF
--- a/custom_components/mitsubishi_climate_proxy/README.md
+++ b/custom_components/mitsubishi_climate_proxy/README.md
@@ -116,8 +116,16 @@ configurable (defaults shown):
 | `recompute_event` | `mxz_recompute` | event fired after a write to nudge the coordinator |
 | `comfort_offset` | `6.0` | °F applied to the far band edge in non-coordinator dual-setpoint writes |
 
-**Default is off**, in which case behavior is identical to a plain proxy. A reference coordinator
-package, [ha-mxz-coordinator](https://github.com/dkpnw/ha-mxz-coordinator), pairs with these defaults.
+**Default is off**, in which case behavior is identical to a plain proxy. The companion coordinator,
+**[ha-mxz-coordinator](https://github.com/dkpnw/ha-mxz-coordinator)**, is now a **one-click HACS
+integration** (config-flow): add the repo to HACS, download it, then add the integration from the UI
+and pick your heads and temperature sensors — no YAML editing.
+
+> **Which coordinator install to pair with:** the `input_number.*` / `input_boolean.*` /
+> `input_select.*` writes documented above match ha-mxz-coordinator's **legacy YAML package**. Its
+> **v2.0.0 HACS integration** instead owns its helpers as **`number.*` / `switch.*` / `select.*`**
+> entities, which this proxy mode does not write to yet — so pair the proxy's single-target mode with
+> the **YAML package** for now. The `mxz_recompute` event nudge works with either.
 
 ## Under the Hood: How it solves the UI Glitch
 


### PR DESCRIPTION
Small docs-only follow-up to the merged `coordinator_single_target` mode (#679).

The companion coordinator, [ha-mxz-coordinator](https://github.com/dkpnw/ha-mxz-coordinator), is now a **one-click HACS config-flow integration** (added the repo to HACS → add the integration from the UI). This updates the Coordinator Single-Target Mode section of the proxy README to say so.

It also clarifies a version nuance so users don't get a silent no-op:
- The documented `input_number.*` / `input_boolean.*` / `input_select.*` writes match the coordinator's **legacy YAML package**.
- The coordinator's **v2.0.0 HACS integration** owns its helpers as `number.*` / `switch.*` / `select.*` entities, which this proxy mode does not write to yet — so pair single-target mode with the **YAML package** for now. The `mxz_recompute` event works with either.

README-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)