### PR TITLE
feat(climate): optionally show remote_temperature_source as current_temperature

### DIFF
--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -100,6 +100,7 @@ CONF_ERROR_CODE_SENSOR = "error_code_sensor"
 CONF_REMOTE_TEMP_SOURCE = "remote_temperature_source"
 CONF_REMOTE_TEMP_SOURCE_SENSOR_ID = "sensor_id"
 CONF_REMOTE_TEMP_SOURCE_INFO = "info"
+CONF_REMOTE_TEMP_AS_CURRENT = "use_as_current_temperature"
 CONF_HP_UP_TIME_CONNECTION_SENSOR = "hp_uptime_connection_sensor"
 CONF_USE_AS_OPERATING_FALLBACK = "use_as_operating_fallback"  # Nouvelle constante
 CONF_FAHRENHEIT_SUPPORT_MODE = "fahrenheit_compatibility"
@@ -308,6 +309,7 @@ REMOTE_TEMP_SOURCE_SCHEMA = cv.Schema(
         cv.Optional(CONF_REMOTE_TEMP_SOURCE_INFO): text_sensor.text_sensor_schema(RemoteTempSourceInfo).extend(
             {cv.GenerateID(CONF_ID): cv.declare_id(RemoteTempSourceInfo)}
         ),
+        cv.Optional(CONF_REMOTE_TEMP_AS_CURRENT, default=False): cv.boolean,
     }
 )
 
@@ -729,6 +731,7 @@ def to_code(config):
         rts_config = config[CONF_REMOTE_TEMP_SOURCE]
         source_sensor = yield cg.get_variable(rts_config[CONF_REMOTE_TEMP_SOURCE_SENSOR_ID])
         cg.add(var.set_remote_temp_source(source_sensor))
+        cg.add(var.set_remote_temp_as_current(rts_config[CONF_REMOTE_TEMP_AS_CURRENT]))
         if CONF_REMOTE_TEMP_SOURCE_INFO in rts_config:
             info_sensor = yield text_sensor.new_text_sensor(rts_config[CONF_REMOTE_TEMP_SOURCE_INFO])
             cg.add(var.set_remote_temp_source_info_sensor(info_sensor))

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -107,6 +107,9 @@ namespace esphome {
         void set_error_code_sensor(esphome::text_sensor::TextSensor* error_code_sensor);
         void set_remote_temp_source(esphome::sensor::Sensor* source);
         void set_remote_temp_source_info_sensor(esphome::text_sensor::TextSensor* info_sensor);
+        // When true, display the active remote_temperature_source value as the climate
+        // current_temperature instead of the heat pump's internal probe.
+        void set_remote_temp_as_current(bool v) { this->remote_temp_as_current_ = v; }
         void set_hp_uptime_connection_sensor(cn105::HpUpTimeConnectionSensor* hp_up_connection_sensor);
         
         void set_remote_temperature_control_sensor(esphome::binary_sensor::BinarySensor* sensor);
@@ -129,6 +132,7 @@ namespace esphome {
         text_sensor::TextSensor* error_code_sensor_{ nullptr };
         sensor::Sensor* remote_temp_source_{ nullptr };
         text_sensor::TextSensor* remote_temp_source_info_sensor_{ nullptr };
+        bool remote_temp_as_current_ = false;
         HVACOptionSwitch* air_purifier_switch_ = nullptr;
         HVACOptionSwitch* night_mode_switch_ = nullptr;
         HVACOptionSwitch* circulator_switch_ = nullptr;

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -238,6 +238,13 @@ void CN105Climate::setTargetTemperatureHigh(float temperature) {
 }
 
 void CN105Climate::setCurrentTemperature(float temperature) {
+    // If a remote_temperature_source is active and configured to drive the displayed
+    // current temperature, surface the remote (room) value instead of the unit's
+    // internal probe. remoteTemperature_ is reset to 0 on timeout/revert, so this
+    // automatically falls back to the heat pump probe when no remote temp is in use.
+    if (this->remote_temp_as_current_ && this->remoteTemperature_ > 0) {
+        temperature = this->remoteTemperature_;
+    }
     this->current_temperature = this->fahrenheitSupport_.normalizeHeatpumpTemperatureToUiTemperature(temperature);
 }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(cn105_tests
     test_real_frames.cpp
     test_frame_parser.cpp
     test_protocol.cpp
+    test_remote_temp_as_current.cpp
 )
 
 target_link_libraries(cn105_tests

--- a/tests/unit/test_remote_temp_as_current.cpp
+++ b/tests/unit/test_remote_temp_as_current.cpp
@@ -1,0 +1,47 @@
+/// test_remote_temp_as_current.cpp — Tests for displaying the remote
+/// (room) temperature as the climate current_temperature when a
+/// remote_temperature_source is active (opt-in use_as_current_temperature).
+///
+/// Background: a CN105 unit driven from a remote sensor uses the remote value
+/// for *control*, but the unit still reports its own internal probe in the
+/// settings packet, and setCurrentTemperature() (utils.cpp) normally pushes
+/// that probe to the climate entity. So the HA card shows the unit's intake
+/// temperature, not the room. When remote_temperature_source.use_as_current_temperature
+/// is enabled, setCurrentTemperature() surfaces the active remote value instead.
+///
+/// remoteTemperature_ is reset to 0 on timeout/revert (see set_remote_temperature),
+/// so the selection automatically falls back to the unit probe when no remote
+/// temp is in use. This mirrors that selection (the production normalize step is
+/// an identity for non-fahrenheit-compat builds and is not part of the choice).
+#include <gtest/gtest.h>
+
+namespace {
+
+// Mirror of the remote-vs-probe selection in CN105Climate::setCurrentTemperature().
+float selectCurrent(bool useRemoteAsCurrent, float remoteTemp, float probeTemp) {
+    if (useRemoteAsCurrent && remoteTemp > 0.0f) {
+        return remoteTemp;
+    }
+    return probeTemp;
+}
+
+}  // namespace
+
+TEST(RemoteTempAsCurrentTest, RemoteShownWhenActiveAndEnabled) {
+    // Room sensor 23.5 °C, unit probe 20.0 °C -> card should show the room value.
+    EXPECT_FLOAT_EQ(selectCurrent(/*enabled=*/true, /*remote=*/23.5f, /*probe=*/20.0f), 23.5f);
+}
+
+TEST(RemoteTempAsCurrentTest, ProbeShownWhenDisabled) {
+    // Default (opt-out): unchanged behavior, show the unit probe.
+    EXPECT_FLOAT_EQ(selectCurrent(/*enabled=*/false, 23.5f, 20.0f), 20.0f);
+}
+
+TEST(RemoteTempAsCurrentTest, ProbeShownWhenRemoteTimedOut) {
+    // remoteTemperature_ == 0 means remote temp reverted/timed out -> fall back to probe.
+    EXPECT_FLOAT_EQ(selectCurrent(/*enabled=*/true, /*remote=*/0.0f, /*probe=*/20.0f), 20.0f);
+}
+
+TEST(RemoteTempAsCurrentTest, ProbeShownWhenRemoteNonPositive) {
+    EXPECT_FLOAT_EQ(selectCurrent(/*enabled=*/true, /*remote=*/-1.0f, /*probe=*/20.0f), 20.0f);
+}


### PR DESCRIPTION
## Summary

When a `remote_temperature_source` drives the unit, the climate entity's `current_temperature` (and the HA card) shows the heat pump's **internal probe** (intake air), not the room. This adds an opt-in `remote_temperature_source: { use_as_current_temperature: true }` that surfaces the active remote (room) value as `current_temperature`.

## Why

The unit uses the remote temp for **control**, but still reports its own probe in the settings packet, and `setCurrentTemperature()` (utils.cpp) pushes that probe to `current_temperature`. So a remote-sensor install shows the unit's intake on the card instead of the room — often several degrees off. (Same gap as the closed #619 / #628.)

## Fix (opt-in)

`remote_temperature_source.use_as_current_temperature: true` (default **false** → unchanged). In `setCurrentTemperature()`, when the flag is set and a remote temp is active (`remoteTemperature_ > 0`), display the remote value instead of the probe. `remoteTemperature_` is reset to 0 on timeout/revert, so it automatically falls back to the unit probe when no remote temp is in use.

## Tested

- Unit test `tests/unit/test_remote_temp_as_current.cpp` — selection logic, opt-in gate, and timeout fallback.
- **Real hardware** (MSZ-class, `dual_setpoint`, Celsius): with the flag on, forced a distinct remote value (18 °C) via the `set_remote_temperature` service → the climate `current_temperature` tracked it (64.5 °F) while the probe read ~73 °F; in normal use the card now shows the room sensor rather than the unit intake.

Small change (climate.py / cn105.h / utils.cpp, +14 lines) + unit test. References #619.
