### PR TITLE
fix: honor update_interval on HP uptime connection sensor

### DIFF
--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -742,6 +742,7 @@ def to_code(config):
     if CONF_HP_UP_TIME_CONNECTION_SENSOR in config:
         conf = config[CONF_HP_UP_TIME_CONNECTION_SENSOR]
         hp_connection_sensor_ = yield sensor.new_sensor(conf)
+        yield cg.register_component(hp_connection_sensor_, conf)
         cg.add(var.set_hp_uptime_connection_sensor(hp_connection_sensor_))
 
     if CONF_HARDWARE_SETTINGS in config:

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -436,12 +436,6 @@ void CN105Climate::terminateCycle() {
 
     this->loopCycle.cycleEnded();
 
-    if (this->hp_uptime_connection_sensor_ != nullptr) {
-        // if the uptime connection sensor is configured
-        // we trigger  manual update at the end of a cycle.
-        this->hp_uptime_connection_sensor_->update();
-    }
-
     this->nbCompleteCycles_++;
 }
 void CN105Climate::getErrorInfoFromResponsePacket() {


### PR DESCRIPTION
Hi, I found that when I enabled the hp uptime connection sensor, the api/logs received an update more often than any other attribute. I had claude dig into it:

> `HpUpTimeConnectionSensor` is a `PollingComponent` and its schema exposes `update_interval` (default 60s).
> 
> `to_code` never registered it as a component, so the poller never ran and `update_interval` was a no-op. Instead `update()` was called on every status frame from `terminateCycle()`, publishing the connection uptime ~every climate update_interval (e.g. every 4s) and updating to the API/logs more than necessary.
> 
> Register the sensor so its poller drives `update()` at the configured interval, and drop the per-cycle manual update. `start()`/`stop()` still publish connect/disconnect transitions immediately, so a reset to 0 on reconnect is still prompt.

I tested this manually on my local esp32c6. The update went from every 5-ish seconds to every 60 seconds. This fix works perfectly.

Thanks for your work. I'm running 3 of these on 3 different ducted air handlers and it's all working great.