### PR TITLE
Add MSZ-A24NA support and align A24NA ClampAndRound tests with std::round  DescriptionFix/pr 702 clamp round tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Units tested by project contributors include:
 - `PEFY-P32VMA-E2`
 - `SEZ-KD25VAQ`
 - `SEZ-M50DAL`
-- `MSZ-A24NA`
+- `MSZ-A24NA` (See `msz_a24na_setpoint_table` and `fahrenheit_compatibility`)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The benefits include fully local control over your heat pump system, without rel
 ### New Features
 
 - Support Fahrenheit users better by mapping unit conversions to Mitsubishi's "creative" math, ensuring that HomeAssistant and external thermostats stay in sync. Thanks [@ams2990](https://github.com/ams2990) and [@dsstewa](https://github.com/dsstewa)!
+- Support the MSZ-A24NA setpoint table using a unique bytecode-to-Celsius mapping. Enable with `msz_a24na_setpoint_table: true`. Thanks [@GraphicHealer](https://github.com/GraphicHealer)!
 - Additional components for supported units: vane orientation (fully supporting the Swicago map), compressor frequency for energy monitoring, and i-see sensor.
 - Additional diagnostic sensors for understanding the behavior of the indoor units while in AUTO mode.
 - Additional sensors for power usage and outdoor temperature (not supported by all units).
@@ -81,6 +82,7 @@ Units tested by project contributors include:
 - `PEFY-P32VMA-E2`
 - `SEZ-KD25VAQ`
 - `SEZ-M50DAL`
+- `MSZ-A24NA`
 
 ## Usage
 
@@ -192,7 +194,9 @@ Recommended: start with `10s` and increase (e.g., `30s`) if you still miss early
 
 `installer_mode` enables an extended CN105 connection handshake (CONNECT command `0x5B`) instead of the standard handshake (`0x5A`). Some indoor units (notably some ducted SEZ variants) may require this to unlock installer/service privileges so that Function Settings (ISU / `hardware_settings`) return real values instead of `0`. Default is `false` for maximum compatibility.
 
-`fahrenheit_compatibility` improves compatibility with HomeAssistant installations using Fahrenheit units. Mitsubishi uses a custom lookup table to convert F to C which doesn't correspond to the actual math in all cases. This can result in external thermostats and HomeAssistant "disagreeing" on what the current setpoint is. Setting this value to `standard` (or `alt` for alternative conversion tables) forces the component to use the same lookup tables, resulting in more consistent display of setpoints. Recommended for Fahrenheit users. (See https://github.com/echavet/MitsubishiCN105ESPHome/pull/298.)
+`fahrenheit_compatibility` improves compatibility with HomeAssistant installations using Fahrenheit units. Mitsubishi uses a custom lookup table to convert F to C which doesn't correspond to the actual math in all cases. This can result in external thermostats and HomeAssistant "disagreeing" on what the current setpoint is. Setting this value to `standard` (or `alt` for alternative conversion tables) forces the component to use the same lookup tables, resulting in more consistent display of setpoints. For MSZ-A24NA and similar units, use `msz_a24na` to use the MSZ-A24NA Fahrenheit-to-Celsius table. Recommended for Fahrenheit users. (See https://github.com/echavet/MitsubishiCN105ESPHome/pull/298.)
+
+`msz_a24na_setpoint_table` enables the alternate temperature setpoint encoding used by some indoor units such as the MSZ-A24NA. Default is `false`. When enabled, setpoints are encoded/decoded with the A24NA lookup table and restricted to 16–31 °C in 0.5 °C steps. If you use Fahrenheit with an A24NA, pair this with `fahrenheit_compatibility: "msz_a24na"`.
 
 `use_as_operating_fallback` in the `stage_sensor` enables a fallback mechanism for the activity indicator (idle/heating/cooling/etc.). By default, the activity status is based on the compressor running state. When this option is enabled, the system uses an OR logic: it shows active status if the compressor is running OR if the stage sensor indicates activity (not IDLE). This is particularly useful for 2-stage heating systems where the second stage (e.g., gas heating) may be active while the compressor is off. (See https://github.com/echavet/MitsubishiCN105ESPHome/issues/277 and https://github.com/echavet/MitsubishiCN105ESPHome/issues/469)
 
@@ -209,9 +213,11 @@ climate:
         target_temperature: 1
         current_temperature: 0.5
     # Fahrenheit compatibility mode - uses Mitsubishi's "custom" unit conversions, set to
-    # "standard" (or "alt") for better support of Fahrenheit units in HomeAssistant.
-    # Options: "disabled" (default), "standard", "alt"
+    # "standard" (or "alt" or "msz_a24na") for better support of Fahrenheit units in HomeAssistant.
+    # Options: "disabled" (default), "standard", "alt", "msz_a24na"
     fahrenheit_compatibility: "disabled"
+    # MSZ-A24NA setpoint table - set to true for units that use the unique A24NA setpoint byte mapping
+    msz_a24na_setpoint_table: false
     # Timeout and communication settings
     remote_temperature_timeout: 30min
     remote_temperature_keepalive_interval: 20s # Auto re-send external temp (like Kumo)
@@ -651,9 +657,11 @@ climate:
         target_temperature: 1
         current_temperature: 0.5
     # Fahrenheit compatibility mode - uses Mitsubishi's "custom" unit conversions, set to
-    # "standard" (or "alt") for better support of Fahrenheit units in HomeAssistant.
-    # Options: "disabled" (default), "standard", "alt"
+    # "standard" (or "alt" or "msz_a24na") for better support of Fahrenheit units in HomeAssistant.
+    # Options: "disabled" (default), "standard", "alt", "msz_a24na"
     fahrenheit_compatibility: "disabled"
+    # MSZ-A24NA setpoint table - set to true for units that use the unique A24NA setpoint byte mapping
+    msz_a24na_setpoint_table: false
     # Timeout and communication settings
     remote_temperature_timeout: 30min
     remote_temperature_keepalive_interval: 20s # Auto re-send external temp (like Kumo)
@@ -765,8 +773,8 @@ climate:
     id: hp
     # ... other options ...
     remote_temperature_source:
-      sensor_id: ha_remote_temp       # References the sensor declared above
-      info:                           # Optional: exposes a text sensor showing the source name
+      sensor_id: ha_remote_temp # References the sensor declared above
+      info: # Optional: exposes a text sensor showing the source name
         name: "Remote Temp Source"
     remote_temperature_timeout: 30min
     remote_temperature_keepalive_interval: 20s
@@ -1108,6 +1116,7 @@ climate:
             1: "ON (Default)"
             2: "OFF"
 ```
+
 ## Experimental Features
 
 The following features are considered experimental. They rely on protocol bytes or behaviors that are not officially documented by Mitsubishi and may not work on all unit models. Community feedback is essential to validate and improve them.
@@ -1127,6 +1136,7 @@ climate:
 ```
 
 The sensor appears in Home Assistant with:
+
 - **Unit**: `%`
 - **Icon**: `mdi:water-percent`
 - **Category**: Diagnostic
@@ -1141,11 +1151,11 @@ Some Mitsubishi wall-mount units feature split vanes with two independent motors
 
 There are two split-vane configurations depending on your unit's hardware:
 
-| `vane_type` | Description | Tested on |
-|------------|-------------|-----------|
-| `standard` (default) | Single motor per vane axis — standard behavior | Most units |
-| `split_horizontal` | Dual horizontal (wide) vane motors — both left/right wide-vane motors are synchronized | MSZ-GE24NA (confirmed by [@polskikrol](https://github.com/polskikrol)) |
-| `split_vertical` | Dual vertical vane motors — experimental, awaiting community validation | MSZ-FH series (pending) |
+| `vane_type`          | Description                                                                            | Tested on                                                              |
+| -------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `standard` (default) | Single motor per vane axis — standard behavior                                         | Most units                                                             |
+| `split_horizontal`   | Dual horizontal (wide) vane motors — both left/right wide-vane motors are synchronized | MSZ-GE24NA (confirmed by [@polskikrol](https://github.com/polskikrol)) |
+| `split_vertical`     | Dual vertical vane motors — experimental, awaiting community validation                | MSZ-FH series (pending)                                                |
 
 #### Example: Split Horizontal Vane Configuration
 
@@ -1164,7 +1174,7 @@ climate:
       mode: [HEAT_COOL, COOL, HEAT, DRY, FAN_ONLY]
       fan_mode: [AUTO, QUIET, LOW, MEDIUM, HIGH]
       swing_mode: ["OFF", HORIZONTAL, VERTICAL]
-      vane_type: split_horizontal  # ← Synchronizes both horizontal vane motors
+      vane_type: split_horizontal # ← Synchronizes both horizontal vane motors
 ```
 
 #### Example: Split Vertical Vane Configuration (Experimental)
@@ -1180,7 +1190,7 @@ climate:
       name: Vertical Vane
     supports:
       swing_mode: ["OFF", VERTICAL]
-      vane_type: split_vertical  # ← Experimental: synchronizes both vertical vane motors
+      vane_type: split_vertical # ← Experimental: synchronizes both vertical vane motors
 ```
 
 > [!WARNING]
@@ -1192,56 +1202,57 @@ Since ESPHome 2026.4.0, a native `mitsubishi_cn105` component (by [@crnjan](http
 
 ### Feature Comparison
 
-| Feature | This Project (echavet) | Native ESPHome (crnjan) |
-|---------|:---------------------:|:----------------------:|
-| **Basic HVAC control** (power, mode, fan, temp) | ✅ | ✅ |
-| **Half-degree setpoint** (0.5°C steps) | ✅ | ✅ (PR [#15919](https://github.com/esphome/esphome/pull/15919)) |
-| **HEAT_COOL / AUTO mode** | ✅ Hybrid dual setpoint | ✅ HEAT_COOL mapping (PR [#15748](https://github.com/esphome/esphome/pull/15748)) |
-| **Dual setpoint support** | ✅ Native via `supports: dual_setpoint: true` | ❌ Single setpoint only |
-| **Vertical vane (swing) select** | ✅ 5 positions + SWING | ⏳ Draft PR [#15653](https://github.com/esphome/esphome/pull/15653) |
-| **Horizontal vane (wide vane) select** | ✅ All 8 positions + SWING | ⏳ Draft PR [#15653](https://github.com/esphome/esphome/pull/15653) |
-| **Dual/split vane support** | ✅ `vane_type: split_horizontal / split_vertical` | ❌ Not planned |
-| **Remote temperature sensor** | ✅ Built-in keep-alive + debounce + native binding | ⏳ Open PR [#15558](https://github.com/esphome/esphome/pull/15558) (lambda-only) |
-| **Remote temperature timeout / fallback** | ✅ Configurable auto-revert to internal sensor | ❌ Manual only |
-| **Fahrenheit compatibility** | ✅ Standard + Alt lookup tables | ⏳ Draft PR [#15488](https://github.com/esphome/esphome/pull/15488) |
-| **Compressor frequency sensor** | ✅ | ❌ Not planned |
-| **Input power sensor** | ✅ | ❌ Not planned |
-| **Energy (kWh) sensor** | ✅ | ❌ Not planned |
-| **Outside air temperature** | ✅ | ❌ Not planned |
-| **Operating status / hvac_action** | ✅ Based on compressor state | ❌ |
-| **Stage / Sub Mode / Auto Sub Mode** | ✅ Diagnostic sensors | ❌ |
-| **Runtime hours sensor** | ✅ | ❌ |
-| **iSee sensor** | ✅ | ❌ |
-| **Hardware settings (ISU / Function codes)** | ✅ Read & Write (0x20/0x22 packets) | ❌ Not planned |
-| **Installer mode (0x5B handshake)** | ✅ | ❌ |
-| **Air purifier / Night mode / Circulator** | ✅ Switches (0x08 packets) | ❌ |
-| **Airflow control select** | ✅ | ❌ |
-| **HACS integration (Climate Proxy)** | ✅ Dynamic single/dual slider UI | N/A (native HA integration) |
-| **ESP8266 support** | ✅ | ✅ |
-| **ESP32 (Arduino + IDF)** | ✅ | ✅ |
-| **RP2040 / BK72xx** | ❌ | ✅ |
+| Feature                                         |               This Project (echavet)               |                              Native ESPHome (crnjan)                              |
+| ----------------------------------------------- | :------------------------------------------------: | :-------------------------------------------------------------------------------: |
+| **Basic HVAC control** (power, mode, fan, temp) |                         ✅                         |                                        ✅                                         |
+| **Half-degree setpoint** (0.5°C steps)          |                         ✅                         |          ✅ (PR [#15919](https://github.com/esphome/esphome/pull/15919))          |
+| **HEAT_COOL / AUTO mode**                       |              ✅ Hybrid dual setpoint               | ✅ HEAT_COOL mapping (PR [#15748](https://github.com/esphome/esphome/pull/15748)) |
+| **Dual setpoint support**                       |   ✅ Native via `supports: dual_setpoint: true`    |                              ❌ Single setpoint only                              |
+| **Vertical vane (swing) select**                |               ✅ 5 positions + SWING               |        ⏳ Draft PR [#15653](https://github.com/esphome/esphome/pull/15653)        |
+| **Horizontal vane (wide vane) select**          |             ✅ All 8 positions + SWING             |        ⏳ Draft PR [#15653](https://github.com/esphome/esphome/pull/15653)        |
+| **Dual/split vane support**                     | ✅ `vane_type: split_horizontal / split_vertical`  |                                  ❌ Not planned                                   |
+| **Remote temperature sensor**                   | ✅ Built-in keep-alive + debounce + native binding | ⏳ Open PR [#15558](https://github.com/esphome/esphome/pull/15558) (lambda-only)  |
+| **Remote temperature timeout / fallback**       |   ✅ Configurable auto-revert to internal sensor   |                                  ❌ Manual only                                   |
+| **Fahrenheit compatibility**                    |          ✅ Standard + Alt lookup tables           |        ⏳ Draft PR [#15488](https://github.com/esphome/esphome/pull/15488)        |
+| **Compressor frequency sensor**                 |                         ✅                         |                                  ❌ Not planned                                   |
+| **Input power sensor**                          |                         ✅                         |                                  ❌ Not planned                                   |
+| **Energy (kWh) sensor**                         |                         ✅                         |                                  ❌ Not planned                                   |
+| **Outside air temperature**                     |                         ✅                         |                                  ❌ Not planned                                   |
+| **Operating status / hvac_action**              |            ✅ Based on compressor state            |                                        ❌                                         |
+| **Stage / Sub Mode / Auto Sub Mode**            |               ✅ Diagnostic sensors                |                                        ❌                                         |
+| **Runtime hours sensor**                        |                         ✅                         |                                        ❌                                         |
+| **iSee sensor**                                 |                         ✅                         |                                        ❌                                         |
+| **Hardware settings (ISU / Function codes)**    |        ✅ Read & Write (0x20/0x22 packets)         |                                  ❌ Not planned                                   |
+| **Installer mode (0x5B handshake)**             |                         ✅                         |                                        ❌                                         |
+| **Air purifier / Night mode / Circulator**      |             ✅ Switches (0x08 packets)             |                                        ❌                                         |
+| **Airflow control select**                      |                         ✅                         |                                        ❌                                         |
+| **HACS integration (Climate Proxy)**            |          ✅ Dynamic single/dual slider UI          |                            N/A (native HA integration)                            |
+| **ESP8266 support**                             |                         ✅                         |                                        ✅                                         |
+| **ESP32 (Arduino + IDF)**                       |                         ✅                         |                                        ✅                                         |
+| **RP2040 / BK72xx**                             |                         ❌                         |                                        ✅                                         |
 
 ### Architecture & Reliability Comparison
 
-| Aspect | This Project | Native ESPHome |
-|--------|:----------:|:------------:|
-| **Installation** | `external_components` reference | Zero-config, built into ESPHome core |
-| **UART communication** | Non-blocking, byte-by-byte in `loop()` with debounce and retry. Battle-tested across 100+ real units | Non-blocking FSM with `FrameParser`. Clean design but field-tested on fewer configurations |
-| **Connection recovery** | Multi-layer: UART reinit fallback for ESP-IDF 5.4.x regressions, auto-reconnect, pending packet queue | State machine with `READ_TIMEOUT` state for retry |
-| **Request orchestration** | `RequestScheduler` — prioritized, round-robin multi-packet cycling (settings, room temp, status, timers, HVAC options, standby) | Simple sequential poll: settings → room temp only |
-| **Concurrency protection** | Mutex (ESP32) / emulated mutex (ESP8266) on settings writes | Single-threaded state machine (no contention risk) |
-| **State management** | Distributed booleans (pragmatic, field-proven) | Formal `enum class State` FSM with validated transitions |
-| **Frame parsing** | Inline in main class, overflow-protected (64-byte buffer) | Encapsulated `FrameParser` class, template callback-based (32-byte buffer) |
-| **Type safety** | `const char*` parallel arrays (legacy SwiCago pattern) | `enum class` + `std::optional` + `constexpr` lookup |
-| **Temperature encoding** | Dual A/B encoding, auto-detect | Dual A/B encoding, auto-detect |
-| **Unit test suite** | ❌ (community-validated) | ✅ Full C++ test coverage |
-| **ESPHome API stability** | ⚠️ May require updates on ESPHome major releases | ✅ Maintained by core team, no breaking changes |
-| **Binary size** | ~5900 lines C++ (all features included) | ~700 lines C++ (minimal feature set) |
-| **Codebase maturity** | 2+ years, 600+ issues/PRs, active community | Released April 2026, rapidly evolving |
+| Aspect                     |                                                          This Project                                                           |                                       Native ESPHome                                       |
+| -------------------------- | :-----------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------: |
+| **Installation**           |                                                 `external_components` reference                                                 |                            Zero-config, built into ESPHome core                            |
+| **UART communication**     |              Non-blocking, byte-by-byte in `loop()` with debounce and retry. Battle-tested across 100+ real units               | Non-blocking FSM with `FrameParser`. Clean design but field-tested on fewer configurations |
+| **Connection recovery**    |              Multi-layer: UART reinit fallback for ESP-IDF 5.4.x regressions, auto-reconnect, pending packet queue              |                     State machine with `READ_TIMEOUT` state for retry                      |
+| **Request orchestration**  | `RequestScheduler` — prioritized, round-robin multi-packet cycling (settings, room temp, status, timers, HVAC options, standby) |                     Simple sequential poll: settings → room temp only                      |
+| **Concurrency protection** |                                   Mutex (ESP32) / emulated mutex (ESP8266) on settings writes                                   |                     Single-threaded state machine (no contention risk)                     |
+| **State management**       |                                         Distributed booleans (pragmatic, field-proven)                                          |                  Formal `enum class State` FSM with validated transitions                  |
+| **Frame parsing**          |                                    Inline in main class, overflow-protected (64-byte buffer)                                    |         Encapsulated `FrameParser` class, template callback-based (32-byte buffer)         |
+| **Type safety**            |                                     `const char*` parallel arrays (legacy SwiCago pattern)                                      |                    `enum class` + `std::optional` + `constexpr` lookup                     |
+| **Temperature encoding**   |                                                 Dual A/B encoding, auto-detect                                                  |                               Dual A/B encoding, auto-detect                               |
+| **Unit test suite**        |                                                    ❌ (community-validated)                                                     |                                 ✅ Full C++ test coverage                                  |
+| **ESPHome API stability**  |                                        ⚠️ May require updates on ESPHome major releases                                         |                      ✅ Maintained by core team, no breaking changes                       |
+| **Binary size**            |                                             ~5900 lines C++ (all features included)                                             |                            ~700 lines C++ (minimal feature set)                            |
+| **Codebase maturity**      |                                           2+ years, 600+ issues/PRs, active community                                           |                           Released April 2026, rapidly evolving                            |
 
 ### When to Use Which?
 
 **Choose this project** if you need:
+
 - 🔧 **Full diagnostic visibility** — compressor frequency, power consumption, energy tracking, operating stages
 - 🌡️ **Advanced remote temperature** — built-in keep-alive, auto-timeout fallback, native sensor binding
 - 🎛️ **Complete vane control** — all positions, dual/split vane support for multi-motor units
@@ -1251,6 +1262,7 @@ Since ESPHome 2026.4.0, a native `mitsubishi_cn105` component (by [@crnjan](http
 - 🛡️ **Proven reliability** — battle-tested firmware running on hundreds of units for 2+ years
 
 **Choose the native ESPHome component** if you need:
+
 - 🚀 **Simplest setup** — 5-line YAML, no `external_components` reference
 - 🔒 **Core team maintenance** — guaranteed API compatibility with ESPHome updates
 - ✅ **Unit-tested codebase** — formal state machine, clean architecture

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -103,6 +103,7 @@ CONF_REMOTE_TEMP_SOURCE_INFO = "info"
 CONF_HP_UP_TIME_CONNECTION_SENSOR = "hp_uptime_connection_sensor"
 CONF_USE_AS_OPERATING_FALLBACK = "use_as_operating_fallback"  # Nouvelle constante
 CONF_FAHRENHEIT_SUPPORT_MODE = "fahrenheit_compatibility"
+CONF_MSZ_A24NA_SETPOINT_TABLE = "msz_a24na_setpoint_table"
 CONF_AIRFLOW_CONTROL_SELECT = "airflow_control_select"
 CONF_AIR_PURIFIER_SWITCH = "air_purifier_switch"
 CONF_NIGHT_MODE_SWITCH = "night_mode_switch"
@@ -400,6 +401,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_FAHRENHEIT_SUPPORT_MODE, default="disabled"): cv.enum(
                 FAHRENHEIT_MODES, lower=True
             ),
+            cv.Optional(CONF_MSZ_A24NA_SETPOINT_TABLE, default=False): cv.boolean,
             cv.Optional(
                 CONF_STAGE_SENSOR
             ): STAGE_SENSOR_CONFIG_SCHEMA,  # ModifiÃÂÃÂ© pour le nouveau schÃÂÃÂ©ma
@@ -507,7 +509,7 @@ def to_code(config):
 
         # Set the number of horizontal vanes (Legacy)
         cg.add(var.set_horizontal_vanes(supports.get(CONF_HORIZONTAL_VANES, 1)))
-        
+
         # Set vane type (New)
         vane_type_conf = supports.get(CONF_VANE_TYPE, "standard")
         vane_type_val = VANE_TYPES.get(vane_type_conf, 0)
@@ -692,6 +694,8 @@ def to_code(config):
         f"static_cast<esphome::FahrenheitMode>({fahrenheit_value})"
     )
     cg.add(var.set_use_fahrenheit_support_mode(mode_enum))
+
+    cg.add(var.set_msz_a24na_setpoint_table(config[CONF_MSZ_A24NA_SETPOINT_TABLE]))
 
     # --- TRAITEMENT POUR STAGE_SENSOR AVEC LA NOUVELLE OPTION ---
     if CONF_STAGE_SENSOR in config:

--- a/components/cn105/climate.py
+++ b/components/cn105/climate.py
@@ -128,6 +128,7 @@ FAHRENHEIT_MODES = {
     "disabled": 0,
     "standard": 1,
     "alt": 2,
+    "msz_a24na": 3,
     "false": 0,
     "true": 1,
 }

--- a/components/cn105/cn105.h
+++ b/components/cn105/cn105.h
@@ -82,15 +82,16 @@ namespace esphome {
         void set_stage_sensor(esphome::text_sensor::TextSensor* Stage_sensor);
         void set_use_stage_for_operating_status(bool value);
         void set_use_fahrenheit_support_mode(FahrenheitMode mode);
+        void set_msz_a24na_setpoint_table(bool value);
         void set_air_purifier_switch(HVACOptionSwitch* air_purifier_switch);
         void set_night_mode_switch(HVACOptionSwitch* night_mode_switch);
         void set_circulator_switch(HVACOptionSwitch* circulator_switch);
 
         void add_hardware_setting(HardwareSettingSelect* setting);
         void set_hardware_settings_interval(uint32_t interval_ms) { this->hardware_settings_interval_ms_ = interval_ms; }
-        
+
         // Deprecated: kept for backward compatibility, will map to VaneType::SPLIT_HORIZONTAL
-        void set_horizontal_vanes(int horizontal_vanes) { 
+        void set_horizontal_vanes(int horizontal_vanes) {
             if (horizontal_vanes > 1) {
                 this->vane_type_ = VaneType::SPLIT_HORIZONTAL;
             }
@@ -109,7 +110,7 @@ namespace esphome {
         void set_remote_temp_source(esphome::sensor::Sensor* source);
         void set_remote_temp_source_info_sensor(esphome::text_sensor::TextSensor* info_sensor);
         void set_hp_uptime_connection_sensor(cn105::HpUpTimeConnectionSensor* hp_up_connection_sensor);
-        
+
         void set_remote_temperature_control_sensor(esphome::binary_sensor::BinarySensor* sensor);
         void set_remote_temperature_margin(float margin);
 
@@ -490,6 +491,7 @@ namespace esphome {
         heatpumpFunctions functions;
 
         bool use_temperature_encoding_b_ = false;
+        bool use_msz_a24na_setpoint_table_ = false;
         bool wideVaneAdj;
         bool autoUpdate;
         bool firstRun;

--- a/components/cn105/cn105_protocol.h
+++ b/components/cn105/cn105_protocol.h
@@ -3,6 +3,7 @@
 /// Deps: <cstdint>, <cmath>, <cstring>, <optional> (no ESPHome dependency)
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <cmath>
 #include <cstring>
@@ -73,6 +74,23 @@ inline void encode_remote_temperature(float temperature, uint8_t& enc_a, uint8_t
     float rounded = std::round(temperature * 2.0f);
     enc_a = static_cast<uint8_t>(rounded - 16);
     enc_b = static_cast<uint8_t>(rounded + 128);
+}
+
+/// Decode an MSZ-A24NA setpoint byte (data[5]) into °C.
+/// The A24NA uses the low nibble as the integer part and bit 4 as a +0.5 °C indicator:
+///   temperature = 31.0 - (byte & 0x0F) + 0.5 * ((byte >> 4) & 0x01)
+inline float decode_msz_a24na_setpoint(uint8_t byte) {
+    return 31.0f - static_cast<float>(byte & 0x0F)
+           + 0.5f * static_cast<float>((byte >> 4) & 0x01);
+}
+
+/// Encode a target setpoint temperature (16.0 .. 31.0 °C, 0.5 steps) into the MSZ-A24NA byte format.
+inline uint8_t encode_msz_a24na_setpoint(float temperature) {
+    float clamped = std::clamp(temperature, 16.0f, 31.0f);
+    int half_steps = static_cast<int>(std::round((clamped - 16.0f) * 2.0f));
+    uint8_t low = static_cast<uint8_t>(15 - (half_steps / 2));
+    uint8_t high = static_cast<uint8_t>((half_steps % 2) << 4);
+    return high | low;
 }
 
 // ════════════════════════════════════════════════════════════════

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -263,7 +263,8 @@ void CN105Climate::set_hp_uptime_connection_sensor(cn105::HpUpTimeConnectionSens
 void CN105Climate::set_use_fahrenheit_support_mode(FahrenheitMode mode) {
     this->fahrenheitSupport_.setUseFahrenheitSupportMode(mode);
     const char* mode_name = (mode == FahrenheitMode::OFF) ? "disabled" :
-                           (mode == FahrenheitMode::STANDARD) ? "standard" : "alt";
+                           (mode == FahrenheitMode::STANDARD) ? "standard" :
+                           (mode == FahrenheitMode::ALT) ? "alt" : "msz_a24na";
     ESP_LOGI(TAG, "Fahrenheit compatibility mode: %s", mode_name);
 }
 

--- a/components/cn105/extraComponents.cpp
+++ b/components/cn105/extraComponents.cpp
@@ -267,6 +267,15 @@ void CN105Climate::set_use_fahrenheit_support_mode(FahrenheitMode mode) {
     ESP_LOGI(TAG, "Fahrenheit compatibility mode: %s", mode_name);
 }
 
+void CN105Climate::set_msz_a24na_setpoint_table(bool value) {
+    this->use_msz_a24na_setpoint_table_ = value;
+    if (value) {
+        this->traits_.set_visual_min_temperature(16.0f);
+        this->traits_.set_visual_max_temperature(31.0f);
+    }
+    ESP_LOGI(TAG, "MSZ-A24NA setpoint table: %s", value ? "enabled" : "disabled");
+}
+
 void CN105Climate::add_hardware_setting(HardwareSettingSelect* setting) {
     this->hardware_settings_.push_back(setting);
     setting->setCallbackFunction([this, setting](const std::string& value, int int_value) {

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -182,7 +182,9 @@ void CN105Climate::getSettingsFromResponsePacket() {
     ESP_LOGD("Decoder", "[iSee  : %d]", receivedSettings.iSee);
     ESP_LOGD("Decoder", "[Mode  : %s]", receivedSettings.mode);
 
-    if (data[11] != 0x00) {
+    if (this->use_msz_a24na_setpoint_table_) {
+        receivedSettings.temperature = cn105_protocol::decode_msz_a24na_setpoint(data[5]);
+    } else if (data[11] != 0x00) {
         int temp = data[11];
         temp -= 128;
         receivedSettings.temperature = (float)temp / 2;
@@ -277,7 +279,7 @@ void CN105Climate::getSettingsFromResponsePacket() {
                     receivedRunStates.airflow_control = this->currentRunStates.airflow_control;
                 }
             } else {
-                // For some reason data[10] is 0x80, but the i-See sensor is not active. 
+                // For some reason data[10] is 0x80, but the i-See sensor is not active.
                 // Some units let us do this, but the real mode is unknown (might be powersave) and the i-See sensor does not get activated.
                 //receivedRunStates.airflow_control = "N/A";
                 ESP_LOGD("Decoder", "i-See sensor not present/active.");
@@ -429,7 +431,7 @@ void CN105Climate::getHVACOptionsFromResponsePacket() {
 void CN105Climate::terminateCycle() {
     if (this->shouldSendExternalTemperature_) {
         // We will receive ACK packet for this.
-        // Sending WantedSettings must be delayed in this case (lastSend timestamp updated).        
+        // Sending WantedSettings must be delayed in this case (lastSend timestamp updated).
         ESP_LOGD(LOG_REMOTE_TEMP, "Sending remote temperature...");
         this->sendRemoteTemperature();
     }
@@ -629,7 +631,7 @@ void CN105Climate::publishStateToHA(heatpumpSettings& settings) {
 void CN105Climate::heatpumpUpdate(heatpumpSettings& settings) {
     // settings correponds to current settings
     ESP_LOGV(LOG_SETTINGS_TAG, "Settings received");
-    // if received settings are different from current settings 
+    // if received settings are different from current settings
     if (settings != this->currentSettings) {
         ESP_LOGI(LOG_SETTINGS_TAG, "Settings changed, updating HA states");
         this->debugSettings("current", this->currentSettings);

--- a/components/cn105/hp_writings.cpp
+++ b/components/cn105/hp_writings.cpp
@@ -229,7 +229,11 @@ void CN105Climate::createPacket(uint8_t* packet) {
     }
 
     if (wantedSettings.temperature != -1) {
-        if (!use_temperature_encoding_b_) {
+        if (this->use_msz_a24na_setpoint_table_) {
+            ESP_LOGD(TAG, "temperature (A24NA table) -> %f", getTemperatureSetting());
+            packet[10] = cn105_protocol::encode_msz_a24na_setpoint(getTemperatureSetting());
+            packet[6] += CONTROL_PACKET_1[2];
+        } else if (!use_temperature_encoding_b_) {
             ESP_LOGD(TAG, "temperature (tempmode is false) -> %f", getTemperatureSetting());
             int idx = lookupByteMapIndex(TEMP_MAP, 16, getTemperatureSetting(), "temperature (write)");
             if (idx >= 0) { packet[10] = TEMP[idx]; packet[6] += CONTROL_PACKET_1[2]; } else { ESP_LOGW(TAG, "Ignoring invalid temperature setting while building packet"); }

--- a/components/cn105/localization.h
+++ b/components/cn105/localization.h
@@ -24,6 +24,9 @@ namespace esphome {
 
             // Select the appropriate conversion table based on mode
             const std::vector<std::pair<float, float>>& localTable = getActiveTable();
+            if (localTable.empty()) {
+                return c;
+            }
 
             auto it = std::upper_bound(
                 localTable.begin(),
@@ -34,13 +37,16 @@ namespace esphome {
                 }
             );
 
-            if (it == localTable.begin() || it == localTable.end()) {
-                return c;
+            float fahrenheitResult;
+            if (it == localTable.begin()) {
+                fahrenheitResult = localTable.front().first;
+            } else if (it == localTable.end()) {
+                fahrenheitResult = localTable.back().first;
+            } else {
+                auto prev = it;
+                --prev;
+                fahrenheitResult = std::abs(prev->second - c) < std::abs(it->second - c) ? prev->first : it->first;
             }
-
-            auto prev = it;
-            --prev;
-            float fahrenheitResult = std::abs(prev->second - c) < std::abs(it->second - c) ? prev->first : it->first;
 
             return (fahrenheitResult - 32.0f) / 1.8f;
         }
@@ -52,6 +58,9 @@ namespace esphome {
 
             // Select the appropriate conversion table based on mode
             const std::vector<std::pair<float, float>>& localTable = getActiveTable();
+            if (localTable.empty()) {
+                return c;
+            }
 
             float fahrenheitInput = (c * 1.8f) + 32.0f;
 
@@ -63,8 +72,12 @@ namespace esphome {
                 [](const std::pair<float, float>& a, const std::pair<float, float>& b) {
                     return a.first < b.first;
                 });
-            if (it == localTable.begin() || it == localTable.end()) {
-                return c;
+            
+            if (it == localTable.begin()) {
+                return localTable.front().second;
+            }
+            if (it == localTable.end()) {
+                return localTable.back().second;
             }
 
             auto prev = it;

--- a/components/cn105/localization.h
+++ b/components/cn105/localization.h
@@ -7,7 +7,8 @@ namespace esphome {
     enum class FahrenheitMode {
         OFF = 0,
         STANDARD = 1,
-        ALT = 2
+        ALT = 2,
+        MSZ_A24NA = 3
     };
 
     class FahrenheitSupport {
@@ -22,8 +23,7 @@ namespace esphome {
             }
 
             // Select the appropriate conversion table based on mode
-            const std::vector<std::pair<float, float>>& localTable =
-                (fahrenheit_mode_ == FahrenheitMode::ALT) ? fahrenheitToCelsiusTableAlt : fahrenheitToCelsiusTable;
+            const std::vector<std::pair<float, float>>& localTable = getActiveTable();
 
             auto it = std::upper_bound(
                 localTable.begin(),
@@ -51,8 +51,7 @@ namespace esphome {
             }
 
             // Select the appropriate conversion table based on mode
-            const std::vector<std::pair<float, float>>& localTable =
-                (fahrenheit_mode_ == FahrenheitMode::ALT) ? fahrenheitToCelsiusTableAlt : fahrenheitToCelsiusTable;
+            const std::vector<std::pair<float, float>>& localTable = getActiveTable();
 
             float fahrenheitInput = (c * 1.8f) + 32.0f;
 
@@ -75,6 +74,18 @@ namespace esphome {
         }
 
     private:
+        const std::vector<std::pair<float, float>>& getActiveTable() {
+            switch (fahrenheit_mode_) {
+                case FahrenheitMode::ALT:
+                    return fahrenheitToCelsiusTableAlt;
+                case FahrenheitMode::MSZ_A24NA:
+                    return fahrenheitToCelsiusTableMszA24na;
+                case FahrenheitMode::STANDARD:
+                default:
+                    return fahrenheitToCelsiusTable;
+            }
+        }
+
         FahrenheitMode fahrenheit_mode_ = FahrenheitMode::OFF;
 
         // Given a temperature in Celsius that was converted from Fahrenheit, converts
@@ -96,6 +107,15 @@ namespace esphome {
             {76, 24.5}, {77, 25.0}, {78, 25.5}, {79, 26.0}, {80, 26.5},
             {81, 27.0}, {82, 28.0}, {83, 28.5}, {84, 29.0}, {85, 29.5},
             {86, 30.0}, {87, 30.5}, {88, 31.0}
+        };
+        const std::vector<std::pair<float, float>> fahrenheitToCelsiusTableMszA24na = {
+            {59, 16.0}, {60, 16.5}, {61, 17.0}, {62, 17.5}, {63, 18.0},
+            {64, 18.5}, {65, 19.0}, {66, 19.5}, {67, 20.0}, {68, 20.5},
+            {69, 21.0}, {70, 21.5}, {71, 22.0}, {72, 22.5}, {73, 23.0},
+            {74, 23.5}, {75, 24.0}, {76, 24.5}, {77, 25.0}, {78, 25.5},
+            {79, 26.0}, {80, 26.5}, {81, 27.0}, {82, 27.5}, {83, 28.0},
+            {84, 28.5}, {85, 29.0}, {86, 29.5}, {87, 30.0}, {88, 30.5},
+            {89, 31.0}
         };
     };
 }

--- a/components/cn105/utils.cpp
+++ b/components/cn105/utils.cpp
@@ -45,6 +45,10 @@ const char* CN105Climate::getIfNotNull(const char* what, const char* defaultValu
  * It returns the temperature setting.
  */
 float CN105Climate::calculateTemperatureSetting(float setting) {
+    if (this->use_msz_a24na_setpoint_table_) {
+        setting = std::round(2.0f * setting) / 2.0f;  // Round to the nearest half-degree.
+        return setting < 16.0f ? 16.0f : (setting > 31.0f ? 31.0f : setting);
+    }
     if (!this->use_temperature_encoding_b_) {
         return cn105_protocol::lookup_index(TEMP_MAP, 16, (int)(setting + 0.5)) > -1 ? setting : TEMP_MAP[0];
     } else {
@@ -407,8 +411,8 @@ void CN105Climate::hpPacketDebug(const uint8_t* packet, unsigned int length, con
         case 0x04: subLabel = ":Status"; break; // Or "Unknown"? 0x04 is RQST_PKT_STATUS in cn105_types.h
         case 0x05: subLabel = ":Standby"; break; // RQST_PKT_STANDBY
         case 0x06: subLabel = ":Status"; break;  // RQST_PKT_HVAC_OPTIONS? Wait, need to check types map.
-                                                 // In cn105_types: 0x06 is RQST_PKT_HVAC_OPTIONS? 
-                                                 // Actually 0x06 in RCVD_PKT is TIMER? 
+                                                 // In cn105_types: 0x06 is RQST_PKT_HVAC_OPTIONS?
+                                                 // Actually 0x06 in RCVD_PKT is TIMER?
                                                  // Let's stick to common ones seen in logs:
                                                  // 02=Settings, 03=RoomTemp, 06=Status/Timers?, 09=Power?
                                                  // 0x09 is RCVD_PKT_STATUS in some contexts or Power?
@@ -416,17 +420,17 @@ void CN105Climate::hpPacketDebug(const uint8_t* packet, unsigned int length, con
                                                  // FC 62 ... 09 ... -> Power/Standby?
                                                  // FC 62 ... 06 ... -> Status?
         case 0x09: subLabel = ":Power"; break;
-        case 0x10: subLabel = ":Hello"; break; // Connect response 
+        case 0x10: subLabel = ":Hello"; break; // Connect response
         case 0x20: subLabel = ":Func1"; break; // Functions part 1
         case 0x22: subLabel = ":Func2"; break; // Functions part 2
         }
     }
-    
-    // For 0x06 specifically, in many logs it's Status or Timers. 
+
+    // For 0x06 specifically, in many logs it's Status or Timers.
     // In types.h: RCVD_PKT_STATUS = 5, RCVD_PKT_TIMER = 6.
     // Let's use generic names if unsure, but user wants semantic.
-    if (packet[5] == 0x06) subLabel = ":Status"; 
-    
+    if (packet[5] == 0x06) subLabel = ":Status";
+
     char fullLabel[20];
     snprintf(fullLabel, sizeof(fullLabel), "%s%s", label, subLabel);
 
@@ -453,7 +457,7 @@ void CN105Climate::hpPacketDebug(const uint8_t* packet, unsigned int length, con
     csStr = byteBuf;
 
 // Output format: [LABEL:SubLabel ] HEADER -> [ PAYLOAD ] CS
-    ESP_LOGD(packetDirection, "%s|%s|->[%s](%s) <%s>", 
+    ESP_LOGD(packetDirection, "%s|%s|->[%s](%s) <%s>",
         log_prefix, headerStr.c_str(), dataStr.c_str(), csStr.c_str(), fullLabel);
 }
 

--- a/tests/unit/test_calculate_temp.cpp
+++ b/tests/unit/test_calculate_temp.cpp
@@ -17,7 +17,11 @@ static int lookupByteMapIndex_int(const int valuesMap[], int len, int lookupValu
 
 // Standalone reimplementation of calculateTemperatureSetting (from utils.cpp)
 // tempMode parameter replaces the `this->tempMode` member access
-static float calculateTemperatureSetting(float setting, bool tempMode) {
+static float calculateTemperatureSetting(float setting, bool tempMode, bool a24na = false) {
+    if (a24na) {
+        setting = std::round(2.0f * setting) / 2.0f;  // Round to the nearest half-degree.
+        return setting < 16.0f ? 16.0f : (setting > 31.0f ? 31.0f : setting);
+    }
     if (!tempMode) {
         return lookupByteMapIndex_int(TEMP_MAP, 16, (int)(setting + 0.5)) > -1 ? setting : TEMP_MAP[0];
     } else {
@@ -107,4 +111,28 @@ TEST(CalculateTempTest, EncodingB_ExactMin_10) {
 TEST(CalculateTempTest, EncodingB_ExactMax_31) {
     float result = calculateTemperatureSetting(31.0f, true);
     EXPECT_FLOAT_EQ(result, 31.0f); // boundary — no clamp
+}
+
+// ========================================================
+// MSZ-A24NA table (a24na = true)
+// ========================================================
+
+TEST(CalculateTempTest, A24na_ClampsMin) {
+    float result = calculateTemperatureSetting(15.0f, false, true);
+    EXPECT_FLOAT_EQ(result, 16.0f);
+}
+
+TEST(CalculateTempTest, A24na_ClampsMax) {
+    float result = calculateTemperatureSetting(32.0f, false, true);
+    EXPECT_FLOAT_EQ(result, 31.0f);
+}
+
+TEST(CalculateTempTest, A24na_RoundsToHalfDegree) {
+    float result = calculateTemperatureSetting(16.3f, false, true);
+    EXPECT_FLOAT_EQ(result, 16.5f);
+}
+
+TEST(CalculateTempTest, A24na_KeepsExactHalfDegree) {
+    float result = calculateTemperatureSetting(21.5f, false, true);
+    EXPECT_FLOAT_EQ(result, 21.5f);
 }

--- a/tests/unit/test_protocol.cpp
+++ b/tests/unit/test_protocol.cpp
@@ -319,3 +319,40 @@ TEST(ProtocolLookupIndexOpt, StringNotFound) {
     auto result = lookup_index_opt(MODE_MAP, 5, "TURBO");
     EXPECT_FALSE(result.has_value());
 }
+
+// ════════════════════════════════════════════════════════════════
+// MSZ-A24NA setpoint table
+// ════════════════════════════════════════════════════════════════
+
+TEST(ProtocolA24naSetpoint, Decode_HighNibbleIsHalfDegree) {
+    EXPECT_FLOAT_EQ(decode_msz_a24na_setpoint(0x0F), 16.0f);
+    EXPECT_FLOAT_EQ(decode_msz_a24na_setpoint(0x1F), 16.5f);
+    EXPECT_FLOAT_EQ(decode_msz_a24na_setpoint(0x0E), 17.0f);
+    EXPECT_FLOAT_EQ(decode_msz_a24na_setpoint(0x1E), 17.5f);
+    EXPECT_FLOAT_EQ(decode_msz_a24na_setpoint(0x00), 31.0f);
+}
+
+TEST(ProtocolA24naSetpoint, Encode_HighNibbleIsHalfDegree) {
+    EXPECT_EQ(encode_msz_a24na_setpoint(16.0f), 0x0F);
+    EXPECT_EQ(encode_msz_a24na_setpoint(16.5f), 0x1F);
+    EXPECT_EQ(encode_msz_a24na_setpoint(17.0f), 0x0E);
+    EXPECT_EQ(encode_msz_a24na_setpoint(17.5f), 0x1E);
+    EXPECT_EQ(encode_msz_a24na_setpoint(31.0f), 0x00);
+}
+
+TEST(ProtocolA24naSetpoint, RoundTrip_AllHalfSteps) {
+    for (int half_steps = 0; half_steps <= 30; ++half_steps) {
+        float temp = 16.0f + half_steps * 0.5f;
+        uint8_t encoded = encode_msz_a24na_setpoint(temp);
+        float decoded = decode_msz_a24na_setpoint(encoded);
+        EXPECT_FLOAT_EQ(decoded, temp) << "half_step=" << half_steps;
+    }
+}
+
+TEST(ProtocolA24naSetpoint, ClampAndRound) {
+    // out-of-range and non-half values are clamped/rounded to the nearest valid step
+    EXPECT_EQ(encode_msz_a24na_setpoint(15.0f), 0x0F);
+    EXPECT_EQ(encode_msz_a24na_setpoint(32.0f), 0x00);
+    EXPECT_EQ(encode_msz_a24na_setpoint(16.25f), 0x0F);
+    EXPECT_EQ(encode_msz_a24na_setpoint(16.75f), 0x1F);
+}

--- a/tests/unit/test_protocol.cpp
+++ b/tests/unit/test_protocol.cpp
@@ -350,9 +350,11 @@ TEST(ProtocolA24naSetpoint, RoundTrip_AllHalfSteps) {
 }
 
 TEST(ProtocolA24naSetpoint, ClampAndRound) {
-    // out-of-range and non-half values are clamped/rounded to the nearest valid step
+    // out-of-range: clamp to [16.0, 31.0]
     EXPECT_EQ(encode_msz_a24na_setpoint(15.0f), 0x0F);
     EXPECT_EQ(encode_msz_a24na_setpoint(32.0f), 0x00);
-    EXPECT_EQ(encode_msz_a24na_setpoint(16.25f), 0x0F);
-    EXPECT_EQ(encode_msz_a24na_setpoint(16.75f), 0x1F);
+    // midpoints between half-degree steps: std::round is half-away-from-zero
+    // 16.25 → 16.5 (0x1F); 16.75 → 17.0 (0x0E)
+    EXPECT_EQ(encode_msz_a24na_setpoint(16.25f), 0x1F);
+    EXPECT_EQ(encode_msz_a24na_setpoint(16.75f), 0x0E);
 }


### PR DESCRIPTION
## Summary

Adds opt-in support for the **MSZ-A24NA** setpoint encoding and Fahrenheit table, based on work from @GraphicHealer in #702, plus a small unit-test fix so CI can go green.

### Features (from #702)

- `msz_a24na_setpoint_table: true` — encode/decode setpoint via the A24NA bytecode table (16–31 °C, 0.5 °C steps)
- `fahrenheit_compatibility: msz_a24na` — linear F→C table for 59–89 °F
- Related Fahrenheit edge-case handling from the original PR

Both options are **opt-in**; units that do not enable them are unchanged.

### CI fix (this PR)

Unit tests failed because `ProtocolA24naSetpoint.ClampAndRound` expected half-down rounding at exact midpoints, while production code correctly uses `std::round` (**half away from zero**):

| Input | Old (incorrect) expectation | Actual (`std::round`) |
|-------|-----------------------------|------------------------|
| 16.25 | `0x0F` (16.0)               | `0x1F` (16.5)          |
| 16.75 | `0x1F` (16.5)               | `0x0E` (17.0)          |

**Change:** update expectations in `tests/unit/test_protocol.cpp` only. No production encode/decode change.

This is not a protocol regression: the A24NA path is new; the test was inconsistent with `encode_msz_a24na_setpoint` and with the rest of the A24NA path (`std::round(2*t)/2`).

## Relationship to #702

Supersedes / unblocks [echavet/MitsubishiCN105ESPHome#702](https://github.com/echavet/MitsubishiCN105ESPHome/pull/702) by including the same feature work plus the test alignment needed for green CI. Credit for the feature work: @GraphicHealer.

## Test plan

- [x] Local unit tests: 206/206 pass after the ClampAndRound expectation update
- [ ] CI: Unit Tests (C++) green
- [ ] CI: ESPHome Build runs and is green (`needs: unit-tests`)
- [ ] Smoke-check that default configs (flags off) are unchanged

───

Shorter title if you prefer:

MSZ-A24NA support (#702) + fix ClampAndRound unit tests for CI