### PR TITLE
Update log messages for uint32_t

### DIFF
--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -356,7 +356,7 @@ bool CN105Climate::is_circulator() {
 void CN105Climate::setupUART() {
 
     log_info_uint32(TAG, "setupUART() with baudrate ", this->parent_->get_baud_rate());
-    ESP_LOGI(LOG_CONN_TAG, "setupUART(): baud=%d tx=%d rx=%d (UART port=" PRIu32 ")", this->parent_->get_baud_rate(), this->tx_pin_, this->rx_pin_, this->uart_port_);
+    ESP_LOGI(LOG_CONN_TAG, "setupUART(): baud=" PRIu32 " tx=%d rx=%d (UART port=%d)", this->parent_->get_baud_rate(), this->tx_pin_, this->rx_pin_, this->uart_port_);
     this->setHeatpumpConnected(false);
     // isUARTConnected_ replaced by state_ (set to CONNECTING after successful config below)
 

--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -1,4 +1,4 @@
-
+#include <cinttypes>
 #include "cn105.h"
 #ifdef USE_ESP32
 #include <driver/uart.h>
@@ -145,7 +145,7 @@ void CN105Climate::registerHardwareSettingsRequests() {
     bool is_enabled = false;
 
     if (!this->hardware_settings_.empty()) {
-        ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval %u ms", this->hardware_settings_interval_ms_);
+        ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval " PRIu32 " ms", this->hardware_settings_interval_ms_);
         interval = this->hardware_settings_interval_ms_;
         is_enabled = true;
     }
@@ -356,7 +356,7 @@ bool CN105Climate::is_circulator() {
 void CN105Climate::setupUART() {
 
     log_info_uint32(TAG, "setupUART() with baudrate ", this->parent_->get_baud_rate());
-    ESP_LOGI(LOG_CONN_TAG, "setupUART(): baud=%d tx=%d rx=%d (UART port=%d)", this->parent_->get_baud_rate(), this->tx_pin_, this->rx_pin_, this->uart_port_);
+    ESP_LOGI(LOG_CONN_TAG, "setupUART(): baud=%d tx=%d rx=%d (UART port=" PRIu32 ")", this->parent_->get_baud_rate(), this->tx_pin_, this->rx_pin_, this->uart_port_);
     this->setHeatpumpConnected(false);
     // isUARTConnected_ replaced by state_ (set to CONNECTING after successful config below)
 

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -131,7 +131,7 @@ void CN105Climate::maybe_start_connection_() {
             }
 #endif
             this->transition_to_(DriverState::WAIT_GRACE);
-            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: WiFi connecté, délai de grâce %ums", this->conn_bootstrap_delay_ms_);
+            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: WiFi connecté, délai de grâce " PRIu32 "ms", this->conn_bootstrap_delay_ms_);
             return;
         }
 

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "cn105.h"
 #ifdef USE_WIFI
 #include "esphome/components/wifi/wifi_component.h"
@@ -119,7 +120,7 @@ void CN105Climate::maybe_start_connection_() {
 #endif
             // WiFi ready (or no WiFi) — check grace delay
             this->transition_to_(DriverState::WAIT_GRACE);
-            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: délai de grâce %ums pour logs OTA", this->conn_bootstrap_delay_ms_);
+            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: délai de grâce " PRIu32 "ms pour logs OTA", this->conn_bootstrap_delay_ms_);
             return;
         }
 

--- a/components/cn105/request_scheduler.cpp
+++ b/components/cn105/request_scheduler.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "request_scheduler.h"
 #include "Globals.h"
 #include "cn105.h"
@@ -181,7 +182,7 @@ void RequestScheduler::send_next_after(uint8_t previous_code, CN105Climate* cont
 
         if (req.interval_ms > 0 && (CUSTOM_MILLIS - req.last_request_time < req.interval_ms) && req.last_request_time > 0) {
             if (req.log_tag) {
-                ESP_LOGD(req.log_tag, "Skipping %s (0x%02X) - interval not elapsed (elapsed: %lu, interval: %u)",
+                ESP_LOGD(req.log_tag, "Skipping %s (0x%02X) - interval not elapsed (elapsed: %lu, interval: " PRIu32 ")",
                     req.description, req.code,
                     (unsigned long)(CUSTOM_MILLIS - req.last_request_time), req.interval_ms);
             }


### PR DESCRIPTION
Some log messages are printing `uint32_t` using `%d` or `%u`.  This is not reliable.

For example, the log message uses `%u` for uint32_t.  On ESPHome for HomeAssistant, this gives a compiler warning:

```
../src/esphome/components/cn105/cn105.cpp: In member function 'void esphome::CN105Climate::registerHardwareSettingsRequests()':
../src/esphome/components/cn105/cn105.cpp:148:37: warning: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  148 |         ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval %u ms", this->hardware_settings_interval_ms_);
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The solution is to use the macro `PRIu32`, which will always match the correct format specifier for `uint32_t`.