### PR TITLE
Fix -Wformat= warnings for uint32_t log arguments

### DIFF
--- a/components/cn105/cn105.cpp
+++ b/components/cn105/cn105.cpp
@@ -145,7 +145,7 @@ void CN105Climate::registerHardwareSettingsRequests() {
     bool is_enabled = false;
 
     if (!this->hardware_settings_.empty()) {
-        ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval %u ms", this->hardware_settings_interval_ms_);
+        ESP_LOGI(LOG_FUNCTIONS_TAG, "Registering function settings requests (0x20/0x22) with interval %" PRIu32 " ms", this->hardware_settings_interval_ms_);
         interval = this->hardware_settings_interval_ms_;
         is_enabled = true;
     }
@@ -356,7 +356,7 @@ bool CN105Climate::is_circulator() {
 void CN105Climate::setupUART() {
 
     log_info_uint32(TAG, "setupUART() with baudrate ", this->parent_->get_baud_rate());
-    ESP_LOGI(LOG_CONN_TAG, "setupUART(): baud=%d tx=%d rx=%d (UART port=%d)", this->parent_->get_baud_rate(), this->tx_pin_, this->rx_pin_, this->uart_port_);
+    ESP_LOGI(LOG_CONN_TAG, "setupUART(): baud=%" PRIu32 " tx=%d rx=%d (UART port=%d)", this->parent_->get_baud_rate(), this->tx_pin_, this->rx_pin_, this->uart_port_);
     this->setHeatpumpConnected(false);
     // isUARTConnected_ replaced by state_ (set to CONNECTING after successful config below)
 

--- a/components/cn105/componentEntries.cpp
+++ b/components/cn105/componentEntries.cpp
@@ -119,7 +119,7 @@ void CN105Climate::maybe_start_connection_() {
 #endif
             // WiFi ready (or no WiFi) — check grace delay
             this->transition_to_(DriverState::WAIT_GRACE);
-            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: délai de grâce %ums pour logs OTA", this->conn_bootstrap_delay_ms_);
+            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: délai de grâce %" PRIu32 "ms pour logs OTA", this->conn_bootstrap_delay_ms_);
             return;
         }
 
@@ -130,7 +130,7 @@ void CN105Climate::maybe_start_connection_() {
             }
 #endif
             this->transition_to_(DriverState::WAIT_GRACE);
-            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: WiFi connecté, délai de grâce %ums", this->conn_bootstrap_delay_ms_);
+            ESP_LOGI(LOG_CONN_TAG, "Bootstrap connexion: WiFi connecté, délai de grâce %" PRIu32 "ms", this->conn_bootstrap_delay_ms_);
             return;
         }
 

--- a/components/cn105/request_scheduler.cpp
+++ b/components/cn105/request_scheduler.cpp
@@ -181,7 +181,7 @@ void RequestScheduler::send_next_after(uint8_t previous_code, CN105Climate* cont
 
         if (req.interval_ms > 0 && (CUSTOM_MILLIS - req.last_request_time < req.interval_ms) && req.last_request_time > 0) {
             if (req.log_tag) {
-                ESP_LOGD(req.log_tag, "Skipping %s (0x%02X) - interval not elapsed (elapsed: %lu, interval: %u)",
+                ESP_LOGD(req.log_tag, "Skipping %s (0x%02X) - interval not elapsed (elapsed: %lu, interval: %" PRIu32 ")",
                     req.description, req.code,
                     (unsigned long)(CUSTOM_MILLIS - req.last_request_time), req.interval_ms);
             }


### PR DESCRIPTION
Fixes #697

## Summary
- `conn_bootstrap_delay_ms_`, `hardware_settings_interval_ms_`, the UART
  baud rate from `get_baud_rate()`, and `req.interval_ms` are all `uint32_t`,
  but were logged with `%u`/`%d`.
- On ESP-IDF/RISC-V targets (e.g. esp32c6, GCC 14.2), `uint32_t` resolves to
  `long unsigned int`, so these produce `-Wformat=` warnings on every build —
  this is the exact warning block reported in #697:

  ```
  warning: format '%u' expects argument of type 'unsigned int', but argument N
  has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  ```

- Switches these 5 call sites to the portable `PRIu32` macro (from
  `<cinttypes>`, already available transitively via `esphome/core/log.h`),
  matching the convention already used throughout `esphome/core` (e.g.
  `scheduler.cpp`). This is correct on every target width, not just the ones
  where `uint32_t == unsigned int`.

## Changes
- `components/cn105/componentEntries.cpp`: lines 122, 133 (`maybe_start_connection_`)
- `components/cn105/cn105.cpp`: line 148 (`registerHardwareSettingsRequests`), line 359 (`setupUART`, only the `baud=` specifier — `tx`/`rx`/`uart_port` stay `%d` since they're `int`)
- `components/cn105/request_scheduler.cpp`: line 184 (`send_next_after`) — the remaining warning site from #697 not covered by the first commit

## Test plan
- [x] Verified standalone with `g++ -Wformat=2 -Wall` against equivalent
      `esp_log_printf_`-shaped calls: no warnings with the fix, reproduces the
      warnings without it.
- [x] Pure string-literal changes — no logic/behavior change.
- [x] Full incremental ESP-IDF build (esp32c6, ESP-IDF 5.5.5) against a real
      device config, rebuilt twice (once per commit): all
      changed object files compile with zero `-Wformat=` warnings, link, and
      produce a valid firmware image.