### PR TITLE
Report defrost as a climate action

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ auto_sub_mode_sensor:
   - `DEFROST` - a cold climate behavior that runs a short AC cycle during heating mode to melt ice from the coils
   - `STANDBY` - unit is off, or has been put into a "sleep" state through AUTO operation on another indoor unit
 
-Some examples of how these all fit together: Unit 1 is in AUTO set to 20C and Unit 2 is in AUTO and set to 20C. Unit 1 senses that the room is 24C and tries to enter `AUTO_COOL`. If Unit 2 wants to heat the room it is in, it will enter `STANDBY` (and in the case of a few units tested, this mean it will go to "sleep" as if it is off, but not really be off) making Unit 1 enter `AUTO_LEADER` sub mode. In future releases, it is planned to make the ACTION in HA match these modes. But at this time this is not implemented.
+Some examples of how these all fit together: Unit 1 is in AUTO set to 20C and Unit 2 is in AUTO and set to 20C. Unit 1 senses that the room is 24C and tries to enter `AUTO_COOL`. If Unit 2 wants to heat the room it is in, it will enter `STANDBY` (and in the case of a few units tested, this mean it will go to "sleep" as if it is off, but not really be off) making Unit 1 enter `AUTO_LEADER` sub mode. With ESPHome 2026.3.0 or newer, `DEFROST` is exposed to HA as the `defrosting` climate action. The other sub-modes are not currently mapped to HA climate actions.
 
 It is also important to note that the Kumo adapter has many more settings that impact the behaviour above (such as thermal fan behaviour) and if you have set these the exact actions the untis take in these modes/submodes/stages is determined by those. Some of these can also be set by remotes and other devices. The setup you have will dictate the exact actions you see. If you have permutations, please share!
 

--- a/components/cn105/climateControls.cpp
+++ b/components/cn105/climateControls.cpp
@@ -582,6 +582,22 @@ void CN105Climate::updateAction() {
     if (this->traits().has_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE)) {
         this->sanitizeDualSetpoints();
     }
+
+    // Defrosting is a transient action while a heating-capable HVAC mode remains
+    // selected. Report it before deriving the normal action from that mode.
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 3, 0)
+    if ((this->mode == climate::CLIMATE_MODE_HEAT ||
+         this->mode == climate::CLIMATE_MODE_HEAT_COOL ||
+         this->mode == climate::CLIMATE_MODE_AUTO) &&
+        this->currentSettings.sub_mode != nullptr &&
+        strcmp(this->currentSettings.sub_mode, "DEFROST") == 0) {
+        this->action = climate::CLIMATE_ACTION_DEFROSTING;
+        ESP_LOGD(TAG, "Climate mode is: %i", this->mode);
+        ESP_LOGD(TAG, "Climate action is: %i", this->action);
+        return;
+    }
+#endif
+
     switch (this->mode) {
     case climate::CLIMATE_MODE_HEAT:
         //this->setActionIfOperatingAndCompressorIsActiveTo(climate::CLIMATE_ACTION_HEATING);       

--- a/components/cn105/hp_readings.cpp
+++ b/components/cn105/hp_readings.cpp
@@ -140,9 +140,19 @@ void CN105Climate::getPowerFromResponsePacket() {
             }
         }
     }
-    if (this->Sub_mode_sensor_ != nullptr && (!this->currentSettings.sub_mode || strcmp(receivedSettings.sub_mode, this->currentSettings.sub_mode) != 0)) {
+    const bool sub_mode_changed =
+        !this->currentSettings.sub_mode ||
+        strcmp(receivedSettings.sub_mode, this->currentSettings.sub_mode) != 0;
+    if (sub_mode_changed) {
         this->currentSettings.sub_mode = receivedSettings.sub_mode;
-        this->Sub_mode_sensor_->publish_state(receivedSettings.sub_mode);
+        if (this->Sub_mode_sensor_ != nullptr) {
+            this->Sub_mode_sensor_->publish_state(receivedSettings.sub_mode);
+        }
+
+        // Sub-mode is received on a separate packet from the normal status
+        // data, so refresh and publish the climate action immediately.
+        this->updateAction();
+        this->publish_state();
     }
     if (this->Auto_sub_mode_sensor_ != nullptr && (!this->currentSettings.auto_sub_mode || strcmp(receivedSettings.auto_sub_mode, this->currentSettings.auto_sub_mode) != 0)) {
         this->currentSettings.auto_sub_mode = receivedSettings.auto_sub_mode;


### PR DESCRIPTION
Publish climate state when the CN105 sub-mode changes, even when the optional diagnostic sensor is disabled.

Use ESPHome's native defrost action for heating-capable modes on 2026.3.0 and newer, while preserving older-version compatibility and documenting the behavior.